### PR TITLE
feat: auto-sync version from package.json to banner SVG

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,7 @@
+#!/bin/sh
+
+# Sync version from package.json into banner SVG
+node scripts/sync-version.mjs
+
+# If banner was updated, stage it
+git diff --quiet .github/banner.svg || git add .github/banner.svg

--- a/package.json
+++ b/package.json
@@ -6,7 +6,9 @@
     "dev": "next dev",
     "build": "next build",
     "start": "next start",
-    "lint": "eslint"
+    "lint": "eslint",
+    "version:sync": "node scripts/sync-version.mjs",
+    "prepare": "git config core.hooksPath .githooks"
   },
   "dependencies": {
     "framer-motion": "^12.34.3",

--- a/scripts/sync-version.mjs
+++ b/scripts/sync-version.mjs
@@ -1,0 +1,38 @@
+#!/usr/bin/env node
+
+/**
+ * Reads version from package.json and updates it in .github/banner.svg.
+ * Run manually: node scripts/sync-version.mjs
+ * Runs automatically via pre-commit hook.
+ */
+
+import { readFileSync, writeFileSync } from "node:fs";
+import { resolve, dirname } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const ROOT = resolve(dirname(fileURLToPath(import.meta.url)), "..");
+const PKG_PATH = resolve(ROOT, "package.json");
+const BANNER_PATH = resolve(ROOT, ".github/banner.svg");
+
+const VERSION_PATTERN = /(<text[^>]*>)v[\d.]+(<\/text>\s*$)/m;
+
+const pkg = JSON.parse(readFileSync(PKG_PATH, "utf-8"));
+const version = `v${pkg.version}`;
+
+let banner = readFileSync(BANNER_PATH, "utf-8");
+const match = banner.match(VERSION_PATTERN);
+
+if (!match) {
+  console.error("[sync-version] Could not find version text in banner.svg");
+  process.exit(1);
+}
+
+const currentInSvg = match[0].match(/v[\d.]+/)?.[0];
+
+if (currentInSvg === version) {
+  process.exit(0);
+}
+
+banner = banner.replace(VERSION_PATTERN, `$1${version}$2`);
+writeFileSync(BANNER_PATH, banner, "utf-8");
+console.log(`[sync-version] ${currentInSvg} → ${version}`);


### PR DESCRIPTION
## What

Version in `.github/banner.svg` now auto-updates when `package.json` version changes.

## How it works

```
package.json (version) → scripts/sync-version.mjs → .github/banner.svg
```

1. `scripts/sync-version.mjs` — reads version from `package.json`, finds version text in banner SVG via regex, replaces if different
2. `.githooks/pre-commit` — runs sync script before every commit, auto-stages banner.svg if it changed
3. `npm run prepare` — configures `git core.hooksPath` to `.githooks/` on `npm install`

## Usage

**Automatic** — just change version in `package.json` and commit. Hook does the rest.

**Manual** — `npm run version:sync`

## Tested

```
package.json: 0.1.0 → 0.1.1
banner.svg:   [sync-version] v0.1.0 → v0.1.1  ✅
```

## Files
- NEW: `scripts/sync-version.mjs`
- NEW: `.githooks/pre-commit`
- `package.json` — added `version:sync` and `prepare` scripts