### PR TITLE
docs: full SVG visual system — headings, dividers, feature cards

### DIFF
--- a/.github/divider.svg
+++ b/.github/divider.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 32" fill="none">
+  <line x1="0" y1="16" x2="380" y2="16" stroke="#27272a" stroke-width="1"/>
+  <circle cx="400" cy="16" r="3" fill="#f97316" opacity="0.6"/>
+  <circle cx="420" cy="16" r="1.5" fill="#27272a"/>
+  <circle cx="434" cy="16" r="1.5" fill="#27272a"/>
+  <circle cx="448" cy="16" r="1.5" fill="#27272a"/>
+  <circle cx="462" cy="16" r="1.5" fill="#27272a"/>
+  <circle cx="476" cy="16" r="1.5" fill="#27272a"/>
+  <circle cx="500" cy="16" r="3" fill="#06b6d4" opacity="0.4"/>
+  <line x1="520" y1="16" x2="900" y2="16" stroke="#27272a" stroke-width="1"/>
+</svg>

--- a/.github/features.svg
+++ b/.github/features.svg
@@ -1,0 +1,64 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 220" fill="none">
+  <defs>
+    <pattern id="fdots" x="0" y="0" width="16" height="16" patternUnits="userSpaceOnUse">
+      <circle cx="8" cy="8" r="0.5" fill="#3f3f46" opacity="0.3"/>
+    </pattern>
+  </defs>
+  <!-- card 1: config -->
+  <g transform="translate(0, 0)">
+    <rect width="440" height="100" rx="10" fill="#09090b" stroke="#27272a" stroke-width="1"/>
+    <rect width="440" height="100" rx="10" fill="url(#fdots)"/>
+    <g transform="translate(20, 20)" stroke="#f97316" stroke-width="1.5" stroke-linecap="round" fill="none">
+      <rect x="2" y="2" width="20" height="20" rx="4"/>
+      <path d="M9 9h6M9 13h4M9 17h2"/>
+    </g>
+    <text x="56" y="38" font-family="monospace" font-size="12" letter-spacing="2" fill="#f97316">ONE CONFIG</text>
+    <text x="20" y="62" font-family="system-ui, sans-serif" font-size="12" fill="#a1a1aa">All text, links, projects, stats live in</text>
+    <text x="20" y="80" font-family="monospace" font-size="11" fill="#71717a">site-config.ts</text>
+    <text x="107" y="80" font-family="system-ui, sans-serif" font-size="12" fill="#a1a1aa">— change once, updates everywhere</text>
+  </g>
+  <!-- card 2: hand-drawn icons -->
+  <g transform="translate(460, 0)">
+    <rect width="440" height="100" rx="10" fill="#09090b" stroke="#27272a" stroke-width="1"/>
+    <rect width="440" height="100" rx="10" fill="url(#fdots)"/>
+    <g transform="translate(20, 20)" stroke="#06b6d4" stroke-width="1.5" stroke-linecap="round" fill="none">
+      <rect x="5" y="5" width="14" height="14" rx="2"/>
+      <rect x="9" y="9" width="6" height="6" rx="1"/>
+      <path d="M9 2v3M15 2v3M9 19v3M15 19v3M2 9h3M2 15h3M19 9h3M19 15h3"/>
+    </g>
+    <text x="56" y="38" font-family="monospace" font-size="12" letter-spacing="2" fill="#06b6d4">HAND-DRAWN SVG</text>
+    <text x="20" y="62" font-family="system-ui, sans-serif" font-size="12" fill="#a1a1aa">Every service icon built on a 24x24 grid.</text>
+    <text x="20" y="80" font-family="system-ui, sans-serif" font-size="12" fill="#a1a1aa">No icon libraries. No font icons. Just paths.</text>
+  </g>
+  <!-- card 3: magnetic buttons -->
+  <g transform="translate(0, 116)">
+    <rect width="440" height="100" rx="10" fill="#09090b" stroke="#27272a" stroke-width="1"/>
+    <rect width="440" height="100" rx="10" fill="url(#fdots)"/>
+    <g transform="translate(20, 18)" stroke="#f97316" stroke-width="1.5" stroke-linecap="round" fill="none">
+      <circle cx="12" cy="12" r="10"/>
+      <path d="M12 8v8"/>
+      <path d="M8 12h8"/>
+    </g>
+    <text x="56" y="38" font-family="monospace" font-size="12" letter-spacing="2" fill="#f97316">MAGNETIC BUTTONS</text>
+    <text x="20" y="62" font-family="system-ui, sans-serif" font-size="12" fill="#a1a1aa">clientX/clientY on mousemove, offset from center,</text>
+    <text x="20" y="80" font-family="monospace" font-size="11" fill="#71717a">transform: translate(dx, dy)</text>
+    <text x="232" y="80" font-family="system-ui, sans-serif" font-size="12" fill="#a1a1aa">— no library</text>
+  </g>
+  <!-- card 4: grain overlay -->
+  <g transform="translate(460, 116)">
+    <rect width="440" height="100" rx="10" fill="#09090b" stroke="#27272a" stroke-width="1"/>
+    <rect width="440" height="100" rx="10" fill="url(#fdots)"/>
+    <g transform="translate(20, 18)" stroke="#06b6d4" stroke-width="1.5" stroke-linecap="round" fill="none">
+      <rect x="2" y="2" width="20" height="20" rx="3"/>
+      <circle cx="8" cy="9" r="1" fill="#06b6d4" stroke="none" opacity="0.5"/>
+      <circle cx="14" cy="7" r="0.8" fill="#06b6d4" stroke="none" opacity="0.3"/>
+      <circle cx="11" cy="14" r="1.2" fill="#06b6d4" stroke="none" opacity="0.4"/>
+      <circle cx="17" cy="16" r="0.7" fill="#06b6d4" stroke="none" opacity="0.3"/>
+      <circle cx="6" cy="17" r="0.9" fill="#06b6d4" stroke="none" opacity="0.5"/>
+      <circle cx="15" cy="11" r="0.6" fill="#06b6d4" stroke="none" opacity="0.2"/>
+    </g>
+    <text x="56" y="38" font-family="monospace" font-size="12" letter-spacing="2" fill="#06b6d4">GRAIN TEXTURE</text>
+    <text x="20" y="62" font-family="system-ui, sans-serif" font-size="12" fill="#a1a1aa">feTurbulence SVG filter as ::after pseudo.</text>
+    <text x="20" y="80" font-family="system-ui, sans-serif" font-size="12" fill="#a1a1aa">Opacity 0.03 — feel it, don't see it.</text>
+  </g>
+</svg>

--- a/.github/heading-design.svg
+++ b/.github/heading-design.svg
@@ -1,0 +1,12 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 56" fill="none">
+  <rect width="900" height="56" rx="10" fill="#09090b" stroke="#27272a" stroke-width="1"/>
+  <circle cx="28" cy="28" r="5" fill="#06b6d4" opacity="0.8"/>
+  <text x="48" y="33" font-family="monospace" font-size="13" letter-spacing="4" fill="#a1a1aa">WHY IT LOOKS THE WAY IT LOOKS</text>
+  <!-- palette icon -->
+  <g transform="translate(858, 16)" stroke="#27272a" stroke-width="1.5" stroke-linecap="round" fill="none">
+    <circle cx="12" cy="12" r="10"/>
+    <circle cx="8" cy="10" r="1.5" fill="#f97316" stroke="none"/>
+    <circle cx="14" cy="8" r="1.5" fill="#06b6d4" stroke="none"/>
+    <circle cx="10" cy="15" r="1.5" fill="#a1a1aa" stroke="none"/>
+  </g>
+</svg>

--- a/.github/heading-different.svg
+++ b/.github/heading-different.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 56" fill="none">
+  <rect width="900" height="56" rx="10" fill="#09090b" stroke="#27272a" stroke-width="1"/>
+  <circle cx="28" cy="28" r="5" fill="#f97316" opacity="0.8"/>
+  <text x="48" y="33" font-family="monospace" font-size="13" letter-spacing="4" fill="#a1a1aa">WHAT'S DIFFERENT</text>
+  <!-- code icon -->
+  <g transform="translate(856, 16)" stroke="#27272a" stroke-width="1.5" stroke-linecap="round" fill="none">
+    <path d="M6 2l-6 6 6 6"/>
+    <path d="M18 2l6 6-6 6"/>
+    <path d="M15 0L9 16"/>
+  </g>
+</svg>

--- a/.github/heading-license.svg
+++ b/.github/heading-license.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 56" fill="none">
+  <rect width="900" height="56" rx="10" fill="#09090b" stroke="#27272a" stroke-width="1"/>
+  <circle cx="28" cy="28" r="5" fill="#71717a" opacity="0.6"/>
+  <text x="48" y="33" font-family="monospace" font-size="13" letter-spacing="4" fill="#a1a1aa">LICENSE</text>
+  <!-- scale icon -->
+  <g transform="translate(858, 16)" stroke="#27272a" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <path d="M12 2L2 7l10 5 10-5z"/>
+    <path d="M2 17l10 5 10-5"/>
+    <path d="M2 12l10 5 10-5"/>
+  </g>
+</svg>

--- a/.github/heading-run.svg
+++ b/.github/heading-run.svg
@@ -1,0 +1,11 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 56" fill="none">
+  <rect width="900" height="56" rx="10" fill="#09090b" stroke="#27272a" stroke-width="1"/>
+  <circle cx="28" cy="28" r="5" fill="#f97316" opacity="0.8"/>
+  <text x="48" y="33" font-family="monospace" font-size="13" letter-spacing="4" fill="#a1a1aa">RUN LOCALLY</text>
+  <!-- terminal icon -->
+  <g transform="translate(858, 16)" stroke="#27272a" stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round" fill="none">
+    <rect x="0" y="0" width="24" height="24" rx="4"/>
+    <path d="M7 10l4 4-4 4"/>
+    <line x1="15" y1="18" x2="19" y2="18"/>
+  </g>
+</svg>

--- a/README.md
+++ b/README.md
@@ -19,72 +19,65 @@ Every pixel, every icon, every animation — written from scratch.
 
 <br />
 
----
+<picture>
+  <img src=".github/divider.svg" alt="" width="100%" />
+</picture>
 
 <br />
 
-### What's different
-
-Zero content lives in components. One config file drives the entire site:
-
-```
-site-config.ts → all text, all links, all project data, all stats
-globals.css    → every color, every spacing token, every font assignment
-```
-
-Change the config — site updates everywhere. No hunting through JSX.
+<picture>
+  <img src=".github/heading-different.svg" alt="What's different" width="100%" />
+</picture>
 
 <br />
 
-Every service icon is hand-drawn on a `24×24` SVG grid. Not pulled from a library.
-The GitHub and Telegram icons in the footer — also hand-drawn.
-There is no icon dependency besides Lucide for the header nav.
+<picture>
+  <img src=".github/features.svg" alt="One config · Hand-drawn SVG · Magnetic buttons · Grain texture" width="100%" />
+</picture>
 
 <br />
 
-The magnetic button effect doesn't use a library either.
-It reads `clientX`/`clientY` on `mousemove`, calculates offset from center,
-and applies `transform: translate` with a configurable strength multiplier.
-Simple math, no packages.
+<picture>
+  <img src=".github/divider.svg" alt="" width="100%" />
+</picture>
 
 <br />
 
-Grain overlay is a `feTurbulence` SVG filter rendered as a `::after` pseudo-element
-on `<body>`. Fixed position, `pointer-events: none`, `opacity: 0.03`.
-You barely notice it, but remove it and the page feels flat.
+<picture>
+  <img src=".github/heading-design.svg" alt="Why it looks the way it looks" width="100%" />
+</picture>
 
 <br />
 
----
-
-<br />
-
-### Why it looks the way it looks
-
-Dark base is `#09090b` — almost black but not quite. Pure black (`#000`) feels
-like a hole in the screen. This has just enough warmth.
+Dark base is `#09090b` — almost black but not quite.
+Pure black (`#000`) feels like a hole in the screen. This has just enough warmth.
 
 Orange `#f97316` paired with cyan `#06b6d4`. Warm energy against cold tech.
-Two accents from opposite ends of the spectrum — if they were the same hue family
-the whole thing would look monotone.
+Two accents from opposite ends of the spectrum — same hue family
+and the whole thing would look monotone.
 
-Three typefaces, three jobs. **Space Grotesk** for headlines — geometric, techy,
-wide. **Inter** for body text — neutral, readable, disappears. **JetBrains Mono**
-for tags and code snippets — because monospace signals "this is technical" without
-saying it.
+Three typefaces, three jobs.
+**Space Grotesk** for headlines — geometric, techy, wide.
+**Inter** for body — neutral, readable, disappears.
+**JetBrains Mono** for tags and code — monospace signals "this is technical" without saying it.
 
 Hero is asymmetric on purpose. Content pushes left, a rotated side label floats
 right at `rotate(-90deg)`. Services are a `2×2` bento grid, not a list.
 Projects are editorial numbered rows — not cards, because cards all look the same.
-About section splits into text left, animated stats right.
 
 <br />
 
----
+<picture>
+  <img src=".github/divider.svg" alt="" width="100%" />
+</picture>
 
 <br />
 
-### Run locally
+<picture>
+  <img src=".github/heading-run.svg" alt="Run locally" width="100%" />
+</picture>
+
+<br />
 
 ```bash
 git clone https://github.com/Call-me-Boris-The-Razor/essential-hustle.git
@@ -95,15 +88,21 @@ npm run dev
 
 Node >= 22. Opens at `localhost:3000`.
 
-`npm run version:sync` updates the version in the banner SVG from `package.json`.
-This also runs automatically as a pre-commit hook.
+Version in the banner SVG syncs from `package.json` automatically via pre-commit hook.
+Manual: `npm run version:sync`.
 
 <br />
 
----
+<picture>
+  <img src=".github/divider.svg" alt="" width="100%" />
+</picture>
 
 <br />
 
-### License
+<picture>
+  <img src=".github/heading-license.svg" alt="License" width="100%" />
+</picture>
+
+<br />
 
 MIT — do whatever you want with it.


### PR DESCRIPTION
## What changed

Every visual element in the README now uses the same dark theme SVG language. No more mixing markdown `###` and `---` with custom SVGs.

### New SVG assets (6 files)

| File | What it is |
|------|-----------|
| `divider.svg` | Branded horizontal divider — lines, orange dot, cyan dot, dot pattern between |
| `heading-different.svg` | Section header "WHAT'S DIFFERENT" with orange dot + code icon |
| `heading-design.svg` | Section header "WHY IT LOOKS..." with cyan dot + palette icon |
| `heading-run.svg` | Section header "RUN LOCALLY" with orange dot + terminal icon |
| `heading-license.svg` | Section header "LICENSE" with muted dot + layers icon |
| `features.svg` | 2x2 feature card grid: One Config, Hand-drawn SVG, Magnetic Buttons, Grain Texture |

### README structure now

```
banner.svg          ← hero
stack.svg           ← tech stack
divider.svg         ← ---
heading + features  ← what's different (fully SVG)
divider.svg         ← ---
heading + text      ← design rationale
divider.svg         ← ---
heading + code      ← run locally
divider.svg         ← ---
heading + text      ← license
```

All headings: dark bg, rounded corners, monospace uppercase, colored dot accent, right-aligned icon.
All dividers: gradient lines with dot pattern center.
Feature cards: 2x2 grid with custom icons, monospace labels, descriptive text.