### PR TITLE
fix: batch 2 — a11y, scroll-lock, contact config, dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,12 @@
+node_modules
+.next
+.git
+.github
+.githooks
+scripts
+*.md
+.env*
+!.env.example
+.DS_Store
+.vscode
+.idea

--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -64,6 +64,18 @@ html {
   color: var(--text-primary);
 }
 
+/* Reduced motion: disable CSS animations for users who prefer it */
+@media (prefers-reduced-motion: reduce) {
+  *,
+  *::before,
+  *::after {
+    animation-duration: 0.01ms !important;
+    animation-iteration-count: 1 !important;
+    transition-duration: 0.01ms !important;
+    scroll-behavior: auto !important;
+  }
+}
+
 /* Custom scrollbar */
 ::-webkit-scrollbar {
   width: 6px;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,7 @@
 import type { Metadata } from "next";
 import { Space_Grotesk, Inter, JetBrains_Mono } from "next/font/google";
 import { SITE_CONFIG } from "@/lib/site-config";
+import { Providers } from "@/components/providers";
 import "./globals.css";
 
 const spaceGrotesk = Space_Grotesk({
@@ -44,7 +45,7 @@ export default function RootLayout({
       <body
         className={`${spaceGrotesk.variable} ${inter.variable} ${jetbrainsMono.variable} grain antialiased`}
       >
-        {children}
+        <Providers>{children}</Providers>
       </body>
     </html>
   );

--- a/src/components/contact.tsx
+++ b/src/components/contact.tsx
@@ -2,7 +2,7 @@
 
 import { motion } from "framer-motion";
 import { Mail, ArrowUpRight } from "lucide-react";
-import { SITE_CONFIG } from "@/lib/site-config";
+import { SITE_CONFIG, CONTACT_TEXT } from "@/lib/site-config";
 import { MagneticButton } from "@/components/ui/magnetic-button";
 
 export const Contact = () => (
@@ -26,16 +26,15 @@ export const Contact = () => (
           className="relative"
         >
           <span className="font-mono text-sm tracking-widest uppercase text-accent">
-            Let&apos;s talk
+            {CONTACT_TEXT.label}
           </span>
 
           <h2 className="mt-4 font-display text-4xl font-bold tracking-tight md:text-6xl">
-            Have a project in mind?
+            {CONTACT_TEXT.headline}
           </h2>
 
           <p className="mx-auto mt-6 max-w-lg text-lg text-text-secondary">
-            We&apos;re always looking for interesting engineering challenges.
-            Drop us a line and let&apos;s build something great.
+            {CONTACT_TEXT.description}
           </p>
 
           <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,12 +1,17 @@
 "use client";
 
-import { useState } from "react";
+import { useState, useEffect } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Menu, X } from "lucide-react";
 import { SITE_CONFIG, NAV_LINKS } from "@/lib/site-config";
 
 export const Header = () => {
   const [mobileOpen, setMobileOpen] = useState(false);
+
+  useEffect(() => {
+    document.body.style.overflow = mobileOpen ? "hidden" : "";
+    return () => { document.body.style.overflow = ""; };
+  }, [mobileOpen]);
 
   return (
     <header className="fixed top-0 z-50 w-full border-b border-border/50 bg-bg/80 backdrop-blur-xl">

--- a/src/components/providers.tsx
+++ b/src/components/providers.tsx
@@ -1,0 +1,8 @@
+"use client";
+
+import { MotionConfig } from "framer-motion";
+import type { ReactNode } from "react";
+
+export const Providers = ({ children }: { children: ReactNode }) => (
+  <MotionConfig reducedMotion="user">{children}</MotionConfig>
+);

--- a/src/lib/site-config.ts
+++ b/src/lib/site-config.ts
@@ -94,3 +94,10 @@ export const ABOUT_TEXT = {
     { value: "24/7", label: "Monitoring" },
   ],
 } as const;
+
+export const CONTACT_TEXT = {
+  label: "Let's talk",
+  headline: "Have a project in mind?",
+  description:
+    "We're always looking for interesting engineering challenges. Drop us a line and let's build something great.",
+} as const;


### PR DESCRIPTION
Closes #5, #11, #12, #14

### #5 — prefers-reduced-motion
- CSS `@media (prefers-reduced-motion: reduce)` kills all CSS animations/transitions
- `MotionConfig reducedMotion="user"` wraps app via `Providers` component — Framer Motion respects OS setting

### #11 — mobile menu scroll lock
- `useEffect` toggles `document.body.style.overflow` when mobile menu opens/closes
- Cleanup on unmount

### #12 — contact text in config
- Added `CONTACT_TEXT` to `site-config.ts` (label, headline, description)
- `contact.tsx` now imports from config instead of hardcoding

### #14 — .dockerignore
- Excludes node_modules, .next, .git, .github, scripts, *.md, .env*, IDE dirs

### Verified
- `tsc --noEmit` — 0 errors