### PR TITLE
feat: SEO, custom 404, section dividers

### DIFF
--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,0 +1,21 @@
+import { SITE_CONFIG } from "@/lib/site-config";
+
+export default function NotFound() {
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center px-6">
+      <span className="font-mono text-sm tracking-widest text-accent">404</span>
+      <h1 className="mt-4 font-display text-5xl font-bold tracking-tight md:text-7xl">
+        Page not found<span className="text-accent">.</span>
+      </h1>
+      <p className="mt-4 max-w-md text-center text-lg text-text-secondary">
+        This page doesn&apos;t exist. Maybe the URL is wrong, or the page was moved.
+      </p>
+      <a
+        href="/"
+        className="mt-8 rounded-full bg-accent px-8 py-3.5 text-sm font-semibold text-bg transition-colors hover:bg-accent-hover"
+      >
+        Back to {SITE_CONFIG.name}
+      </a>
+    </div>
+  );
+}

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -5,6 +5,7 @@ import { Projects } from "@/components/projects";
 import { About } from "@/components/about";
 import { Contact } from "@/components/contact";
 import { Footer } from "@/components/footer";
+import { SectionDivider } from "@/components/ui/section-divider";
 
 export default function Home() {
   return (
@@ -12,9 +13,13 @@ export default function Home() {
       <Header />
       <main>
         <Hero />
+        <SectionDivider />
         <Services />
+        <SectionDivider />
         <Projects />
+        <SectionDivider />
         <About />
+        <SectionDivider />
         <Contact />
       </main>
       <Footer />

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,0 +1,9 @@
+import type { MetadataRoute } from "next";
+import { SITE_CONFIG } from "@/lib/site-config";
+
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: { userAgent: "*", allow: "/" },
+    sitemap: `https://${SITE_CONFIG.domain}/sitemap.xml`,
+  };
+}

--- a/src/app/sitemap.ts
+++ b/src/app/sitemap.ts
@@ -1,0 +1,13 @@
+import type { MetadataRoute } from "next";
+import { SITE_CONFIG } from "@/lib/site-config";
+
+export default function sitemap(): MetadataRoute.Sitemap {
+  return [
+    {
+      url: `https://${SITE_CONFIG.domain}`,
+      lastModified: new Date(),
+      changeFrequency: "monthly",
+      priority: 1,
+    },
+  ];
+}

--- a/src/components/ui/section-divider.tsx
+++ b/src/components/ui/section-divider.tsx
@@ -1,0 +1,11 @@
+export const SectionDivider = () => (
+  <div className="mx-auto max-w-7xl px-6">
+    <div className="flex items-center gap-4">
+      <div className="h-px flex-1 bg-gradient-to-r from-transparent via-border to-transparent" />
+      <div className="h-1.5 w-1.5 rounded-full bg-accent opacity-40" />
+      <div className="h-px w-8 bg-border-light" />
+      <div className="h-1.5 w-1.5 rounded-full bg-accent-2 opacity-30" />
+      <div className="h-px flex-1 bg-gradient-to-r from-transparent via-border to-transparent" />
+    </div>
+  </div>
+);


### PR DESCRIPTION
Closes #8, #10, #17

### #8 — robots.txt + sitemap
- `src/app/robots.ts` — auto-generates robots.txt with sitemap reference
- `src/app/sitemap.ts` — auto-generates sitemap.xml with domain from site-config

### #10 — custom 404
- `src/app/not-found.tsx` — dark theme, accent dot, "Page not found." headline, back button
- Matches site typography and color system

### #17 — section dividers
- `src/components/ui/section-divider.tsx` — gradient lines + orange/cyan accent dots
- Inserted between Hero→Services→Projects→About→Contact in page.tsx

### Verified
- `tsc --noEmit` — 0 errors