### PR TITLE
feat: v0.2.0 — OG image, version bump, changelog

### DIFF
--- a/.github/banner.svg
+++ b/.github/banner.svg
@@ -40,7 +40,7 @@
   <rect x="406" y="230" width="114" height="28" rx="14" fill="#111113" stroke="#27272a" stroke-width="1"/>
   <text x="418" y="249" font-family="monospace" font-size="11" fill="#a1a1aa">Framer Motion</text>
   <!-- version -->
-  <text x="60" y="295" font-family="monospace" font-size="11" letter-spacing="1.5" fill="#71717a">v0.1.0</text>
+  <text x="60" y="295" font-family="monospace" font-size="11" letter-spacing="1.5" fill="#71717a">v0.2.0</text>
   <!-- side decoration -->
   <line x1="840" y1="60" x2="840" y2="260" stroke="#27272a" stroke-width="1" stroke-dasharray="4 4"/>
   <text x="855" y="168" font-family="monospace" font-size="9" letter-spacing="3" fill="#3f3f46" transform="rotate(90, 855, 168)">essentialhustle.dev</text>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,30 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.2.0] - 2025-02-25
+
+### Added
+- Custom 404 page matching site theme
+- robots.txt and sitemap.xml (auto-generated via Next.js)
+- OG image (SVG, 1200x630) + Twitter card metadata
+- Active nav link highlighting via IntersectionObserver + aria-current
+- Reusable icon components (DevOps, AI, Embedded, Web, GitHub, Telegram)
+- Section dividers between all page sections
+- GitHub Actions CI pipeline (lint + type check + build)
+- .dockerignore for production builds
+- Providers component with MotionConfig reducedMotion
+
+### Fixed
+- prefers-reduced-motion: CSS media query + Framer Motion MotionConfig
+- Mobile menu body scroll lock
+- Contact section text moved to site-config (single source of truth)
+- Grain overlay z-index lowered from 9999 to 50
+
+### Changed
+- README rewritten with custom SVG visual system (banner, stack, headings, dividers, features)
+- Version in banner SVG auto-syncs from package.json via pre-commit hook
+- Inline SVG icons extracted into src/components/ui/icons.tsx
+
 ## [0.1.0] - 2025-02-25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "essential-hustle",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "private": true,
   "scripts": {
     "dev": "next dev",

--- a/public/og-image.svg
+++ b/public/og-image.svg
@@ -1,0 +1,41 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 1200 630" fill="none">
+  <defs>
+    <radialGradient id="og-glow" cx="70%" cy="30%" r="50%">
+      <stop offset="0%" stop-color="#f97316" stop-opacity="0.12"/>
+      <stop offset="100%" stop-color="#09090b" stop-opacity="0"/>
+    </radialGradient>
+    <radialGradient id="og-glow2" cx="20%" cy="75%" r="40%">
+      <stop offset="0%" stop-color="#06b6d4" stop-opacity="0.07"/>
+      <stop offset="100%" stop-color="#09090b" stop-opacity="0"/>
+    </radialGradient>
+    <pattern id="og-dots" x="0" y="0" width="24" height="24" patternUnits="userSpaceOnUse">
+      <circle cx="12" cy="12" r="0.8" fill="#3f3f46" opacity="0.4"/>
+    </pattern>
+  </defs>
+  <rect width="1200" height="630" fill="#09090b"/>
+  <rect width="1200" height="630" fill="url(#og-dots)"/>
+  <rect width="1200" height="630" fill="url(#og-glow)"/>
+  <rect width="1200" height="630" fill="url(#og-glow2)"/>
+  <!-- tag -->
+  <rect x="80" y="160" width="180" height="30" rx="15" fill="none" stroke="#27272a" stroke-width="1"/>
+  <circle cx="98" cy="175" r="5" fill="#f97316" opacity="0.8"/>
+  <text x="112" y="180" font-family="monospace" font-size="12" letter-spacing="2.5" fill="#a1a1aa">ENGINEERING</text>
+  <!-- title -->
+  <text x="80" y="280" font-family="system-ui, -apple-system, sans-serif" font-weight="800" font-size="72" fill="#fafafa">Essential Hustle</text>
+  <text x="718" y="280" font-family="system-ui, -apple-system, sans-serif" font-weight="800" font-size="72" fill="#f97316">.</text>
+  <!-- subtitle -->
+  <text x="80" y="330" font-family="system-ui, sans-serif" font-size="24" fill="#a1a1aa">We build what others outsource.</text>
+  <!-- tech tags -->
+  <rect x="80" y="400" width="80" height="32" rx="16" fill="#111113" stroke="#27272a" stroke-width="1"/>
+  <text x="96" y="421" font-family="monospace" font-size="12" fill="#a1a1aa">DevOps</text>
+  <rect x="172" y="400" width="42" height="32" rx="16" fill="#111113" stroke="#27272a" stroke-width="1"/>
+  <text x="183" y="421" font-family="monospace" font-size="12" fill="#a1a1aa">AI</text>
+  <rect x="226" y="400" width="100" height="32" rx="16" fill="#111113" stroke="#27272a" stroke-width="1"/>
+  <text x="240" y="421" font-family="monospace" font-size="12" fill="#a1a1aa">Embedded</text>
+  <rect x="338" y="400" width="62" height="32" rx="16" fill="#111113" stroke="#27272a" stroke-width="1"/>
+  <text x="352" y="421" font-family="monospace" font-size="12" fill="#a1a1aa">Web</text>
+  <!-- domain -->
+  <text x="80" y="560" font-family="monospace" font-size="14" letter-spacing="2" fill="#71717a">essentialhustle.dev</text>
+  <!-- side line -->
+  <line x1="1120" y1="100" x2="1120" y2="530" stroke="#27272a" stroke-width="1" stroke-dasharray="4 4"/>
+</svg>

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -32,6 +32,13 @@ export const metadata: Metadata = {
     description: SITE_CONFIG.description,
     siteName: SITE_CONFIG.name,
     type: "website",
+    images: [{ url: "/og-image.svg", width: 1200, height: 630, alt: SITE_CONFIG.name }],
+  },
+  twitter: {
+    card: "summary_large_image",
+    title: `${SITE_CONFIG.name} — ${SITE_CONFIG.tagline}`,
+    description: SITE_CONFIG.description,
+    images: ["/og-image.svg"],
   },
 };
 


### PR DESCRIPTION
Closes #7. Version bump 0.1.0 → 0.2.0. OG image + Twitter card metadata. CHANGELOG updated. #19 closed as not_planned.