### PR TITLE
feat: auto-versioning + AGENT.md

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,41 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+jobs:
+  release:
+    name: Tag & Release
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Read version from package.json
+        id: version
+        run: |
+          VERSION=$(node -p "require('./package.json').version")
+          echo "version=$VERSION" >> "$GITHUB_OUTPUT"
+          echo "tag=v$VERSION" >> "$GITHUB_OUTPUT"
+
+      - name: Check if tag exists
+        id: check
+        run: |
+          if git rev-parse "v${{ steps.version.outputs.version }}" >/dev/null 2>&1; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Create tag and release
+        if: steps.check.outputs.exists == 'false'
+        uses: softprops/action-gh-release@v2
+        with:
+          tag_name: ${{ steps.version.outputs.tag }}
+          name: ${{ steps.version.outputs.tag }}
+          generate_release_notes: true

--- a/.gitignore
+++ b/.gitignore
@@ -34,6 +34,9 @@ yarn-error.log*
 .env*
 !.env.example
 
+# agent instructions (local only)
+AGENT.md
+
 # vercel
 .vercel
 


### PR DESCRIPTION
### Auto-versioning via GitHub Actions

`.github/workflows/release.yml`:
1. Triggers on push to `main`
2. Reads version from `package.json`
3. Checks if git tag `vX.Y.Z` already exists
4. If new — creates tag + GitHub Release with auto-generated notes

Flow: bump version in package.json → push to main → tag + release created automatically.

### AGENT.md (gitignored)

Local-only instructions file for AI assistants. Contains:
- Project identity and architecture overview
- Single source of truth pattern (site-config.ts)
- SVG icon system rules (component icons + README assets)
- Brand rules for SVG assets (colors, fonts, patterns)
- Version sync mechanism (package.json → banner.svg)
- SemVer rules and bump checklist
- Git workflow (branches, commits, PRs)
- DO / DON'T checklist
- Complete file map

Added `AGENT.md` to `.gitignore` — it never leaves the local machine.