### PR TITLE
feat: LLM-friendly site — all 9 issues

### DIFF
--- a/public/.well-known/security.txt
+++ b/public/.well-known/security.txt
@@ -1,0 +1,4 @@
+Contact: mailto:security@essentialhustle.dev
+Preferred-Languages: en
+Canonical: https://essentialhustle.dev/.well-known/security.txt
+Expires: 2027-01-01T00:00:00.000Z

--- a/public/humans.txt
+++ b/public/humans.txt
@@ -1,0 +1,17 @@
+/* TEAM */
+Studio: Essential Hustle
+Site: https://essentialhustle.dev
+Contact: hello [at] essentialhustle.dev
+Location: Asia
+
+/* THANKS */
+Next.js: https://nextjs.org
+Tailwind CSS: https://tailwindcss.com
+Framer Motion: https://www.framer.com/motion
+Lucide Icons: https://lucide.dev
+Vercel: https://vercel.com
+
+/* SITE */
+Standards: HTML5, CSS3, ES2024
+Components: React 19, TypeScript 5
+Software: Next.js 16, Tailwind CSS 4

--- a/public/llms-full.txt
+++ b/public/llms-full.txt
@@ -1,0 +1,98 @@
+# Essential Hustle — Full Context for LLMs
+
+> Engineering studio based in Asia. We build infrastructure, integrate AI,
+> ship embedded firmware, and develop web applications.
+> Every project runs in production.
+
+---
+
+## About
+
+Essential Hustle is a small engineering team that ships across the entire
+technology stack — from embedded C firmware to React dashboards, from Docker
+infrastructure to custom AI deployments.
+
+We operate across 4 countries with 10+ production systems running at 99.9% uptime.
+24/7 monitoring on all deployed infrastructure.
+
+---
+
+## Services
+
+### DevOps & Cloud
+Docker orchestration, CI/CD pipelines, server hardening, monitoring.
+Production-grade infrastructure that scales.
+Technologies: Docker, CI/CD, Nginx, Linux, Monitoring
+
+### AI Integration
+On-premise LLM deployment, speech synthesis, whisper transcription,
+custom AI pipelines on your own hardware.
+Technologies: LLM, TTS, STT, Ollama, GPU Inference
+
+### Embedded & IoT
+Custom firmware, drone flight controllers, telemetry systems,
+hardware multiplexors. From PCB to cloud.
+Technologies: C/C++, MAVLink, STM32, Custom Protocols
+
+### Web Development
+Full-stack applications with React, Next.js, Fastify.
+Real-time dashboards, SaaS platforms, admin panels.
+Technologies: React, Next.js, TypeScript, PostgreSQL
+
+---
+
+## Projects
+
+### Sortina (production)
+Logistics rate management platform with multi-role access and real-time data.
+Built with React, Fastify, Prisma, Docker.
+
+### Drone Control Center (active)
+Ground station for drone fleet management with live telemetry and mission planning.
+Built with Python, MAVLink, WebSocket, Flask.
+
+### China Business Tours (production)
+Platform connecting businesses with 258+ tech companies for organized factory visits.
+Built with Next.js, Supabase, TypeScript.
+
+### Video Multiplexor (active)
+Custom hardware and firmware for multi-channel analog video switching
+with serial control.
+Built with C, STM32, CRSF, Custom PCB.
+
+---
+
+## Technical Stack
+
+This website is built with:
+- Next.js 16 (App Router) — framework
+- React 19 — UI library
+- TypeScript 5 — type safety
+- Tailwind CSS 4 — styling via CSS custom properties
+- Framer Motion 12 — scroll animations with reduced-motion support
+- Custom SVG icons — hand-drawn on 24x24 grid, no icon libraries
+
+Design system:
+- Dark theme: #09090b background, #f97316 orange accent, #06b6d4 cyan accent
+- Typography: Space Grotesk (headlines), Inter (body), JetBrains Mono (code/tags)
+- All content centralized in a single configuration file
+
+---
+
+## Contact
+
+- Website: https://essentialhustle.dev
+- Email: hello@essentialhustle.dev
+- Telegram: https://t.me/essentialhustle
+- GitHub: https://github.com/Call-me-Boris-The-Razor
+
+---
+
+## Machine-Readable Resources
+
+- Sitemap: https://essentialhustle.dev/sitemap.xml
+- robots.txt: https://essentialhustle.dev/robots.txt
+- JSON API: https://essentialhustle.dev/api/site-summary
+- Structured data: JSON-LD schema.org in page head
+- Security: https://essentialhustle.dev/.well-known/security.txt
+- Humans: https://essentialhustle.dev/humans.txt

--- a/public/llms.txt
+++ b/public/llms.txt
@@ -1,0 +1,34 @@
+# Essential Hustle
+
+> Engineering studio — DevOps, AI, Embedded, Web
+
+Essential Hustle is a small engineering team based in Asia that builds
+infrastructure, integrates AI, ships embedded firmware, and develops web apps.
+Every project runs in production. No prototypes gathering dust.
+
+## Services
+
+- DevOps & Cloud: Docker orchestration, CI/CD pipelines, server hardening, monitoring
+- AI Integration: On-premise LLM deployment, speech synthesis, whisper transcription, custom pipelines
+- Embedded & IoT: Custom firmware, drone flight controllers, telemetry systems, hardware multiplexors
+- Web Development: Full-stack React, Next.js, Fastify — dashboards, SaaS, admin panels
+
+## Projects
+
+- Sortina: Logistics rate management platform (React, Fastify, Prisma, Docker) — production
+- Drone Control Center: Ground station with live telemetry and mission planning (Python, MAVLink) — active
+- China Business Tours: Platform connecting businesses with 258+ tech companies (Next.js, Supabase) — production
+- Video Multiplexor: Multi-channel analog video switching with serial control (C, STM32) — active
+
+## Contact
+
+- Email: hello@essentialhustle.dev
+- Telegram: https://t.me/essentialhustle
+- GitHub: https://github.com/Call-me-Boris-The-Razor
+
+## Links
+
+- Homepage: https://essentialhustle.dev
+- Sitemap: https://essentialhustle.dev/sitemap.xml
+- JSON API: https://essentialhustle.dev/api/site-summary
+- Full context: https://essentialhustle.dev/llms-full.txt

--- a/src/app/api/site-summary/route.ts
+++ b/src/app/api/site-summary/route.ts
@@ -1,0 +1,44 @@
+import { NextResponse } from "next/server";
+import {
+  SITE_CONFIG,
+  SERVICES,
+  PROJECTS,
+  ABOUT_TEXT,
+  CONTACT_TEXT,
+} from "@/lib/site-config";
+
+export const GET = () =>
+  NextResponse.json({
+    name: SITE_CONFIG.name,
+    domain: SITE_CONFIG.domain,
+    tagline: SITE_CONFIG.tagline,
+    description: SITE_CONFIG.description,
+    contact: {
+      email: SITE_CONFIG.email,
+      telegram: SITE_CONFIG.telegram,
+      github: SITE_CONFIG.github,
+    },
+    services: SERVICES.map((s) => ({
+      id: s.id,
+      title: s.title,
+      description: s.description,
+      tags: [...s.tags],
+    })),
+    projects: PROJECTS.map((p) => ({
+      id: p.id,
+      title: p.title,
+      description: p.description,
+      status: p.status,
+      tags: [...p.tags],
+    })),
+    about: {
+      headline: ABOUT_TEXT.headline,
+      paragraphs: [...ABOUT_TEXT.paragraphs],
+      stats: ABOUT_TEXT.stats.map((s) => ({ ...s })),
+    },
+    contact_text: {
+      label: CONTACT_TEXT.label,
+      headline: CONTACT_TEXT.headline,
+      description: CONTACT_TEXT.description,
+    },
+  });

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import { Space_Grotesk, Inter, JetBrains_Mono } from "next/font/google";
 import { SITE_CONFIG } from "@/lib/site-config";
 import { Providers } from "@/components/providers";
+import { JsonLd } from "@/components/json-ld";
 import "./globals.css";
 
 const spaceGrotesk = Space_Grotesk({
@@ -40,6 +41,16 @@ export const metadata: Metadata = {
     description: SITE_CONFIG.description,
     images: ["/og-image.svg"],
   },
+  alternates: {
+    canonical: `https://${SITE_CONFIG.domain}`,
+  },
+  other: {
+    author: SITE_CONFIG.name,
+    publisher: SITE_CONFIG.name,
+    topic: "Engineering Services, DevOps, AI, Embedded Systems, Web Development",
+    classification: "Technology Services",
+    category: "Technology",
+  },
 };
 
 export default function RootLayout({
@@ -49,9 +60,22 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className="dark">
+      <head>
+        <JsonLd />
+        <link rel="author" href="/humans.txt" />
+        <link rel="alternate" type="application/json" href="/api/site-summary" />
+      </head>
       <body
         className={`${spaceGrotesk.variable} ${inter.variable} ${jetbrainsMono.variable} grain antialiased`}
       >
+        <noscript>
+          <div style={{ padding: "2rem", color: "#fafafa", fontFamily: "system-ui" }}>
+            <h1>Essential Hustle — Engineering that moves fast</h1>
+            <p>We build infrastructure, integrate AI, ship embedded firmware, and develop web apps.</p>
+            <p>Services: DevOps &amp; Cloud, AI Integration, Embedded &amp; IoT, Web Development</p>
+            <p>Contact: hello@essentialhustle.dev</p>
+          </div>
+        </noscript>
         <Providers>{children}</Providers>
       </body>
     </html>

--- a/src/app/robots.ts
+++ b/src/app/robots.ts
@@ -1,9 +1,23 @@
 import type { MetadataRoute } from "next";
 import { SITE_CONFIG } from "@/lib/site-config";
 
+const AI_BOTS = [
+  "GPTBot",
+  "ChatGPT-User",
+  "ClaudeBot",
+  "Claude-Web",
+  "PerplexityBot",
+  "GoogleOther",
+  "Amazonbot",
+  "cohere-ai",
+] as const;
+
 export default function robots(): MetadataRoute.Robots {
   return {
-    rules: { userAgent: "*", allow: "/" },
+    rules: [
+      { userAgent: "*", allow: "/" },
+      ...AI_BOTS.map((bot) => ({ userAgent: bot, allow: "/" as const })),
+    ],
     sitemap: `https://${SITE_CONFIG.domain}/sitemap.xml`,
   };
 }

--- a/src/components/about.tsx
+++ b/src/components/about.tsx
@@ -14,12 +14,12 @@ const STAT_VARIANTS = {
 };
 
 export const About = () => (
-  <section id="about" className="relative py-32">
+  <section id="about" aria-labelledby="about-heading" className="relative py-32">
     <div className="mx-auto max-w-7xl px-6">
       <div className="grid gap-16 md:grid-cols-2">
         {/* Left — text */}
         <div>
-          <SectionHeading label="Who we are" title={ABOUT_TEXT.headline} />
+          <SectionHeading id="about-heading" label="Who we are" title={ABOUT_TEXT.headline} />
           <div className="space-y-4">
             {ABOUT_TEXT.paragraphs.map((p, i) => (
               <p key={i} className="text-lg leading-relaxed text-text-secondary">

--- a/src/components/contact.tsx
+++ b/src/components/contact.tsx
@@ -6,7 +6,7 @@ import { SITE_CONFIG, CONTACT_TEXT } from "@/lib/site-config";
 import { MagneticButton } from "@/components/ui/magnetic-button";
 
 export const Contact = () => (
-  <section id="contact" className="relative py-32">
+  <section id="contact" aria-labelledby="contact-heading" className="relative py-32">
     <div className="mx-auto max-w-7xl px-6">
       <div className="relative overflow-hidden rounded-3xl border border-border bg-surface-1 px-8 py-20 text-center md:px-16 md:py-28">
         {/* Decorative gradient */}
@@ -29,7 +29,7 @@ export const Contact = () => (
             {CONTACT_TEXT.label}
           </span>
 
-          <h2 className="mt-4 font-display text-4xl font-bold tracking-tight md:text-6xl">
+          <h2 id="contact-heading" className="mt-4 font-display text-4xl font-bold tracking-tight md:text-6xl">
             {CONTACT_TEXT.headline}
           </h2>
 
@@ -37,7 +37,7 @@ export const Contact = () => (
             {CONTACT_TEXT.description}
           </p>
 
-          <div className="mt-10 flex flex-col items-center justify-center gap-4 sm:flex-row">
+          <address className="mt-10 flex flex-col items-center justify-center gap-4 not-italic sm:flex-row">
             <MagneticButton
               href={`mailto:${SITE_CONFIG.email}`}
               className="inline-flex items-center gap-2 rounded-full bg-accent px-8 py-4 text-sm font-semibold text-bg transition-colors hover:bg-accent-hover"
@@ -53,7 +53,7 @@ export const Contact = () => (
               Telegram
               <ArrowUpRight size={16} />
             </MagneticButton>
-          </div>
+          </address>
         </motion.div>
       </div>
     </div>

--- a/src/components/json-ld.tsx
+++ b/src/components/json-ld.tsx
@@ -1,0 +1,69 @@
+import { SITE_CONFIG, SERVICES } from "@/lib/site-config";
+
+const BASE_URL = `https://${SITE_CONFIG.domain}`;
+
+const organizationSchema = {
+  "@context": "https://schema.org",
+  "@type": "Organization",
+  name: SITE_CONFIG.name,
+  url: BASE_URL,
+  logo: `${BASE_URL}/favicon.svg`,
+  description: SITE_CONFIG.description,
+  email: SITE_CONFIG.email,
+  sameAs: [SITE_CONFIG.github, SITE_CONFIG.telegram],
+  knowsAbout: [
+    "DevOps",
+    "Docker",
+    "CI/CD",
+    "AI Integration",
+    "LLM Deployment",
+    "Embedded Systems",
+    "IoT",
+    "Web Development",
+    "React",
+    "Next.js",
+    "TypeScript",
+  ],
+};
+
+const websiteSchema = {
+  "@context": "https://schema.org",
+  "@type": "WebSite",
+  name: SITE_CONFIG.name,
+  url: BASE_URL,
+  description: SITE_CONFIG.description,
+};
+
+const serviceSchemas = SERVICES.map((service) => ({
+  "@context": "https://schema.org",
+  "@type": "Service",
+  name: service.title,
+  description: service.description,
+  provider: {
+    "@type": "Organization",
+    name: SITE_CONFIG.name,
+    url: BASE_URL,
+  },
+  areaServed: "Worldwide",
+  serviceType: service.tags.join(", "),
+}));
+
+export const JsonLd = () => (
+  <>
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(organizationSchema) }}
+    />
+    <script
+      type="application/ld+json"
+      dangerouslySetInnerHTML={{ __html: JSON.stringify(websiteSchema) }}
+    />
+    {serviceSchemas.map((schema, i) => (
+      <script
+        key={i}
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(schema) }}
+      />
+    ))}
+  </>
+);

--- a/src/components/projects.tsx
+++ b/src/components/projects.tsx
@@ -19,18 +19,19 @@ const ROW_VARIANTS = {
 };
 
 export const Projects = () => (
-  <section id="projects" className="relative py-32">
+  <section id="projects" aria-labelledby="projects-heading" className="relative py-32">
     <div className="mx-auto max-w-7xl px-6">
       <SectionHeading
+        id="projects-heading"
         label="Our work"
         title="Projects"
         description="Real systems running in production. Not demos, not prototypes."
       />
 
       {/* Project list — editorial style, not card grid */}
-      <div className="space-y-0 divide-y divide-border">
+      <ol className="list-none space-y-0 divide-y divide-border">
         {PROJECTS.map((project, i) => (
-          <motion.div
+          <motion.li
             key={project.id}
             custom={i}
             variants={ROW_VARIANTS}
@@ -74,9 +75,9 @@ export const Projects = () => (
                 </span>
               ))}
             </div>
-          </motion.div>
+          </motion.li>
         ))}
-      </div>
+      </ol>
     </div>
   </section>
 );

--- a/src/components/services.tsx
+++ b/src/components/services.tsx
@@ -15,9 +15,10 @@ const CARD_VARIANTS = {
 };
 
 export const Services = () => (
-  <section id="services" className="relative py-32">
+  <section id="services" aria-labelledby="services-heading" className="relative py-32">
     <div className="mx-auto max-w-7xl px-6">
       <SectionHeading
+        id="services-heading"
         label="What we do"
         title="Services"
         description="End-to-end engineering across the full technology stack."
@@ -26,7 +27,7 @@ export const Services = () => (
       {/* Bento grid — asymmetric 2x2 on desktop */}
       <div className="grid gap-4 md:grid-cols-2">
         {SERVICES.map((service, i) => (
-          <motion.div
+          <motion.article
             key={service.id}
             custom={i}
             variants={CARD_VARIANTS}
@@ -61,7 +62,7 @@ export const Services = () => (
 
             {/* Hover glow — top-right corner */}
             <div className="pointer-events-none absolute -right-20 -top-20 h-40 w-40 rounded-full bg-accent/5 opacity-0 blur-3xl transition-opacity group-hover:opacity-100" />
-          </motion.div>
+          </motion.article>
         ))}
       </div>
     </div>

--- a/src/components/ui/section-heading.tsx
+++ b/src/components/ui/section-heading.tsx
@@ -2,14 +2,18 @@ interface SectionHeadingProps {
   label: string;
   title: string;
   description?: string;
+  id?: string;
 }
 
-export const SectionHeading = ({ label, title, description }: SectionHeadingProps) => (
+export const SectionHeading = ({ label, title, description, id }: SectionHeadingProps) => (
   <div className="mb-16">
     <span className="font-mono text-sm tracking-widest uppercase text-accent">
       {label}
     </span>
-    <h2 className="mt-3 font-display text-4xl font-bold tracking-tight text-text-primary md:text-5xl">
+    <h2
+      id={id}
+      className="mt-3 font-display text-4xl font-bold tracking-tight text-text-primary md:text-5xl"
+    >
       {title}
     </h2>
     {description && (


### PR DESCRIPTION
Closes #29, #30, #31, #32, #33, #34, #35, #36, #37

### #29 — llms.txt
- `public/llms.txt` — concise summary for LLM crawlers (services, projects, contacts, links)
- `public/llms-full.txt` — detailed version with tech stack, about, machine-readable resources

### #30 — JSON-LD structured data
- `src/components/json-ld.tsx` — server component rendering Organization + WebSite + 4 Service schemas
- All data pulled from site-config.ts, zero hardcoding

### #31 — AI bot rules
- `robots.ts` — explicit Allow rules for GPTBot, ChatGPT-User, ClaudeBot, Claude-Web, PerplexityBot, GoogleOther, Amazonbot, cohere-ai

### #32 — Semantic HTML
- Service cards: `<div>` → `<article>`
- Project list: `<div>` → `<ol>/<li>`
- Contact links: wrapped in `<address>`
- `<noscript>` fallback with plain text site summary

### #33 — security.txt + humans.txt
- `public/.well-known/security.txt` (RFC 9116)
- `public/humans.txt` — team, thanks, tech stack

### #34 — Meta tags
- `author`, `publisher`, `topic`, `classification`, `category`
- `alternates.canonical` URL

### #35 — /api/site-summary
- `src/app/api/site-summary/route.ts` — full JSON snapshot of all site content

### #36 — Heading hierarchy + aria
- All sections: `aria-labelledby` pointing to heading `id`
- `section-heading.tsx` — new `id` prop
- Verified: H1 (hero) → H2 (sections) → H3 (cards) — no skips

### #37 — Cross-link discovery
- `<link rel="author" href="/humans.txt" />`
- `<link rel="alternate" type="application/json" href="/api/site-summary" />`
- llms.txt references sitemap, JSON API, security.txt, humans.txt

### Verified
- `tsc --noEmit` — 0 errors