### PR TITLE
chore: v0.3.0 — version bump + changelog

### DIFF
--- a/.github/banner.svg
+++ b/.github/banner.svg
@@ -40,7 +40,7 @@
   <rect x="406" y="230" width="114" height="28" rx="14" fill="#111113" stroke="#27272a" stroke-width="1"/>
   <text x="418" y="249" font-family="monospace" font-size="11" fill="#a1a1aa">Framer Motion</text>
   <!-- version -->
-  <text x="60" y="295" font-family="monospace" font-size="11" letter-spacing="1.5" fill="#71717a">v0.2.0</text>
+  <text x="60" y="295" font-family="monospace" font-size="11" letter-spacing="1.5" fill="#71717a">v0.3.0</text>
   <!-- side decoration -->
   <line x1="840" y1="60" x2="840" y2="260" stroke="#27272a" stroke-width="1" stroke-dasharray="4 4"/>
   <text x="855" y="168" font-family="monospace" font-size="9" letter-spacing="3" fill="#3f3f46" transform="rotate(90, 855, 168)">essentialhustle.dev</text>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,26 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.0] - 2025-02-25
+
+### Added
+- llms.txt + llms-full.txt for LLM crawler discovery
+- JSON-LD structured data (Organization, WebSite, 4x Service schemas)
+- Explicit AI bot rules in robots.txt (GPTBot, ClaudeBot, PerplexityBot, etc.)
+- security.txt (RFC 9116) and humans.txt
+- /api/site-summary JSON endpoint with full site content
+- Meta tags for AI attribution (author, publisher, topic, canonical)
+- noscript fallback with plain text summary
+- link tags for humans.txt and JSON API discovery
+- Auto-versioning via GitHub Actions (release.yml)
+- AGENT.md (gitignored) with project rules for AI assistants
+
+### Changed
+- Semantic HTML: article elements for service cards, ol/li for projects, address for contact
+- All sections have aria-labelledby pointing to heading IDs
+- section-heading.tsx supports optional id prop
+- robots.ts refactored with AI_BOTS array
+
 ## [0.2.0] - 2025-02-25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "essential-hustle",
-  "version": "0.2.0",
+  "version": "0.3.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Version bump 0.2.0 → 0.3.0. Banner SVG synced. CHANGELOG updated. Release will be created automatically by release.yml.