### PR TITLE
fix: code review — all 11 senior-level issues (#41-#51)

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,8 +1,21 @@
 import type { NextConfig } from "next";
 
+const SECURITY_HEADERS = [
+  { key: "X-Frame-Options", value: "DENY" },
+  { key: "X-Content-Type-Options", value: "nosniff" },
+  { key: "Referrer-Policy", value: "strict-origin-when-cross-origin" },
+  { key: "Permissions-Policy", value: "camera=(), microphone=(), geolocation=()" },
+  {
+    key: "Strict-Transport-Security",
+    value: "max-age=31536000; includeSubDomains",
+  },
+];
+
 const nextConfig: NextConfig = {
-  /* config options here */
   reactCompiler: true,
+  headers: async () => [
+    { source: "/(.*)", headers: SECURITY_HEADERS },
+  ],
 };
 
 export default nextConfig;

--- a/src/app/api/site-summary/route.ts
+++ b/src/app/api/site-summary/route.ts
@@ -7,6 +7,12 @@ import {
   CONTACT_TEXT,
 } from "@/lib/site-config";
 
+const CACHE_HEADERS = {
+  "Cache-Control": "public, s-maxage=3600, stale-while-revalidate=86400",
+  "Access-Control-Allow-Origin": "*",
+  "Access-Control-Allow-Methods": "GET",
+};
+
 export const GET = () =>
   NextResponse.json({
     name: SITE_CONFIG.name,
@@ -41,4 +47,4 @@ export const GET = () =>
       headline: CONTACT_TEXT.headline,
       description: CONTACT_TEXT.description,
     },
-  });
+  }, { headers: CACHE_HEADERS });

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -1,6 +1,6 @@
 import type { Metadata } from "next";
 import { Space_Grotesk, Inter, JetBrains_Mono } from "next/font/google";
-import { SITE_CONFIG } from "@/lib/site-config";
+import { SITE_CONFIG, SERVICES } from "@/lib/site-config";
 import { Providers } from "@/components/providers";
 import { JsonLd } from "@/components/json-ld";
 import "./globals.css";
@@ -33,13 +33,11 @@ export const metadata: Metadata = {
     description: SITE_CONFIG.description,
     siteName: SITE_CONFIG.name,
     type: "website",
-    images: [{ url: "/og-image.svg", width: 1200, height: 630, alt: SITE_CONFIG.name }],
   },
   twitter: {
     card: "summary_large_image",
     title: `${SITE_CONFIG.name} — ${SITE_CONFIG.tagline}`,
     description: SITE_CONFIG.description,
-    images: ["/og-image.svg"],
   },
   alternates: {
     canonical: `https://${SITE_CONFIG.domain}`,
@@ -69,11 +67,11 @@ export default function RootLayout({
         className={`${spaceGrotesk.variable} ${inter.variable} ${jetbrainsMono.variable} grain antialiased`}
       >
         <noscript>
-          <div style={{ padding: "2rem", color: "#fafafa", fontFamily: "system-ui" }}>
-            <h1>Essential Hustle — Engineering that moves fast</h1>
-            <p>We build infrastructure, integrate AI, ship embedded firmware, and develop web apps.</p>
-            <p>Services: DevOps &amp; Cloud, AI Integration, Embedded &amp; IoT, Web Development</p>
-            <p>Contact: hello@essentialhustle.dev</p>
+          <div style={{ padding: "2rem", color: "var(--text-primary)", fontFamily: "system-ui" }}>
+            <h1>{SITE_CONFIG.name} — {SITE_CONFIG.tagline}</h1>
+            <p>{SITE_CONFIG.description}</p>
+            <p>Services: {SERVICES.map((s) => s.title).join(", ")}</p>
+            <p>Contact: {SITE_CONFIG.email}</p>
           </div>
         </noscript>
         <Providers>{children}</Providers>

--- a/src/app/opengraph-image.tsx
+++ b/src/app/opengraph-image.tsx
@@ -1,0 +1,145 @@
+import { ImageResponse } from "next/og";
+import { SITE_CONFIG, SERVICES } from "@/lib/site-config";
+
+export const alt = SITE_CONFIG.name;
+export const size = { width: 1200, height: 630 };
+export const contentType = "image/png";
+
+export default function OgImage() {
+  return new ImageResponse(
+    (
+      <div
+        style={{
+          width: "100%",
+          height: "100%",
+          display: "flex",
+          flexDirection: "column",
+          justifyContent: "center",
+          padding: "80px",
+          backgroundColor: "#09090b",
+          fontFamily: "system-ui, sans-serif",
+          position: "relative",
+          overflow: "hidden",
+        }}
+      >
+        {/* Gradient orb */}
+        <div
+          style={{
+            position: "absolute",
+            top: "-100px",
+            right: "-50px",
+            width: "500px",
+            height: "500px",
+            borderRadius: "50%",
+            background: "radial-gradient(circle, rgba(249,115,22,0.12) 0%, transparent 70%)",
+          }}
+        />
+
+        {/* Badge */}
+        <div
+          style={{
+            display: "flex",
+            alignItems: "center",
+            gap: "8px",
+            marginBottom: "32px",
+          }}
+        >
+          <div
+            style={{
+              width: "10px",
+              height: "10px",
+              borderRadius: "50%",
+              backgroundColor: "#f97316",
+            }}
+          />
+          <span
+            style={{
+              fontSize: "14px",
+              letterSpacing: "3px",
+              color: "#a1a1aa",
+              fontFamily: "monospace",
+            }}
+          >
+            ENGINEERING
+          </span>
+        </div>
+
+        {/* Title */}
+        <div style={{ display: "flex", alignItems: "baseline" }}>
+          <span
+            style={{
+              fontSize: "72px",
+              fontWeight: 800,
+              color: "#fafafa",
+              lineHeight: 1.1,
+            }}
+          >
+            {SITE_CONFIG.name}
+          </span>
+          <span
+            style={{
+              fontSize: "72px",
+              fontWeight: 800,
+              color: "#f97316",
+            }}
+          >
+            .
+          </span>
+        </div>
+
+        {/* Subtitle */}
+        <span
+          style={{
+            fontSize: "24px",
+            color: "#a1a1aa",
+            marginTop: "16px",
+          }}
+        >
+          {SITE_CONFIG.tagline}
+        </span>
+
+        {/* Service tags */}
+        <div
+          style={{
+            display: "flex",
+            gap: "12px",
+            marginTop: "48px",
+          }}
+        >
+          {SERVICES.map((s) => (
+            <div
+              key={s.id}
+              style={{
+                padding: "8px 20px",
+                borderRadius: "20px",
+                backgroundColor: "#111113",
+                border: "1px solid #27272a",
+                fontSize: "13px",
+                color: "#a1a1aa",
+                fontFamily: "monospace",
+              }}
+            >
+              {s.title}
+            </div>
+          ))}
+        </div>
+
+        {/* Domain */}
+        <span
+          style={{
+            position: "absolute",
+            bottom: "40px",
+            left: "80px",
+            fontSize: "14px",
+            letterSpacing: "2px",
+            color: "#71717a",
+            fontFamily: "monospace",
+          }}
+        >
+          {SITE_CONFIG.domain}
+        </span>
+      </div>
+    ),
+    { ...size },
+  );
+}

--- a/src/components/about.tsx
+++ b/src/components/about.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from "framer-motion";
 import { ABOUT_TEXT } from "@/lib/site-config";
+import { EASE_OUT_EXPO } from "@/lib/motion";
 import { SectionHeading } from "@/components/ui/section-heading";
 
 const STAT_VARIANTS = {
@@ -9,7 +10,7 @@ const STAT_VARIANTS = {
   visible: (i: number) => ({
     opacity: 1,
     scale: 1,
-    transition: { delay: 0.1 * i, duration: 0.4, ease: [0.16, 1, 0.3, 1] as const },
+    transition: { delay: 0.1 * i, duration: 0.4, ease: EASE_OUT_EXPO },
   }),
 };
 

--- a/src/components/contact.tsx
+++ b/src/components/contact.tsx
@@ -3,6 +3,7 @@
 import { motion } from "framer-motion";
 import { Mail, ArrowUpRight } from "lucide-react";
 import { SITE_CONFIG, CONTACT_TEXT } from "@/lib/site-config";
+import { EASE_OUT_EXPO } from "@/lib/motion";
 import { MagneticButton } from "@/components/ui/magnetic-button";
 
 export const Contact = () => (
@@ -22,7 +23,7 @@ export const Contact = () => (
           initial={{ opacity: 0, y: 30 }}
           whileInView={{ opacity: 1, y: 0 }}
           viewport={{ once: true }}
-          transition={{ duration: 0.6, ease: [0.16, 1, 0.3, 1] as const }}
+          transition={{ duration: 0.6, ease: EASE_OUT_EXPO }}
           className="relative"
         >
           <span className="font-mono text-sm tracking-widest uppercase text-accent">
@@ -48,6 +49,8 @@ export const Contact = () => (
 
             <MagneticButton
               href={SITE_CONFIG.telegram}
+              target="_blank"
+              rel="noopener noreferrer"
               className="inline-flex items-center gap-2 rounded-full border border-border px-8 py-4 text-sm font-semibold text-text-primary transition-colors hover:border-border-light hover:bg-surface-2"
             >
               Telegram

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -1,18 +1,27 @@
 "use client";
 
-import { useState, useEffect } from "react";
+import { useState, useEffect, useMemo } from "react";
 import { motion, AnimatePresence } from "framer-motion";
 import { Menu, X } from "lucide-react";
-import { SITE_CONFIG, NAV_LINKS } from "@/lib/site-config";
+import { SITE_CONFIG, NAV_LINKS, HERO_TEXT } from "@/lib/site-config";
 import { useActiveSection } from "@/lib/use-active-section";
 
 export const Header = () => {
   const [mobileOpen, setMobileOpen] = useState(false);
-  const activeSection = useActiveSection(NAV_LINKS.map((l) => l.href));
+  const sectionHrefs = useMemo(() => NAV_LINKS.map((l) => l.href), []);
+  const activeSection = useActiveSection(sectionHrefs);
 
   useEffect(() => {
     document.body.style.overflow = mobileOpen ? "hidden" : "";
     return () => { document.body.style.overflow = ""; };
+  }, [mobileOpen]);
+
+  useEffect(() => {
+    const handleEscape = (e: KeyboardEvent) => {
+      if (e.key === "Escape") setMobileOpen(false);
+    };
+    if (mobileOpen) document.addEventListener("keydown", handleEscape);
+    return () => document.removeEventListener("keydown", handleEscape);
   }, [mobileOpen]);
 
   return (
@@ -42,7 +51,7 @@ export const Header = () => {
             href={`mailto:${SITE_CONFIG.email}`}
             className="rounded-full bg-accent px-5 py-2 text-sm font-medium text-bg transition-colors hover:bg-accent-hover"
           >
-            Get in Touch
+            {HERO_TEXT.ctaContact}
           </a>
         </div>
 
@@ -51,6 +60,7 @@ export const Header = () => {
           onClick={() => setMobileOpen(!mobileOpen)}
           className="text-text-secondary md:hidden"
           aria-label="Toggle menu"
+          aria-expanded={mobileOpen}
         >
           {mobileOpen ? <X size={24} /> : <Menu size={24} />}
         </button>
@@ -83,7 +93,7 @@ export const Header = () => {
                 href={`mailto:${SITE_CONFIG.email}`}
                 className="mt-2 rounded-full bg-accent px-5 py-3 text-center text-sm font-medium text-bg"
               >
-                Get in Touch
+                {HERO_TEXT.ctaContact}
               </a>
             </div>
           </motion.div>

--- a/src/components/hero.tsx
+++ b/src/components/hero.tsx
@@ -2,7 +2,8 @@
 
 import { motion } from "framer-motion";
 import { ArrowDown } from "lucide-react";
-import { SITE_CONFIG } from "@/lib/site-config";
+import { SITE_CONFIG, HERO_TEXT } from "@/lib/site-config";
+import { EASE_OUT_EXPO } from "@/lib/motion";
 import { DotGrid } from "@/components/ui/dot-grid";
 import { MagneticButton } from "@/components/ui/magnetic-button";
 
@@ -11,7 +12,7 @@ const FADE_UP = {
   visible: (i: number) => ({
     opacity: 1,
     y: 0,
-    transition: { delay: 0.15 * i, duration: 0.6, ease: [0.16, 1, 0.3, 1] as const },
+    transition: { delay: 0.15 * i, duration: 0.6, ease: EASE_OUT_EXPO },
   }),
 };
 
@@ -41,7 +42,7 @@ export const Hero = () => (
         >
           <span className="h-2 w-2 rounded-full bg-accent animate-pulse" />
           <span className="font-mono text-xs tracking-wider text-text-secondary">
-            ENGINEERING STUDIO
+            {HERO_TEXT.badge.toUpperCase()}
           </span>
         </motion.div>
 
@@ -53,9 +54,9 @@ export const Hero = () => (
           animate="visible"
           className="font-display text-5xl font-bold leading-[1.1] tracking-tight md:text-7xl lg:text-8xl"
         >
-          We build what
+          {HERO_TEXT.headline[0]}
           <br />
-          <span className="text-accent">others outsource</span>
+          <span className="text-accent">{HERO_TEXT.headline[1]}</span>
           <span className="text-text-muted">.</span>
         </motion.h1>
 
@@ -82,13 +83,13 @@ export const Hero = () => (
             href="#services"
             className="rounded-full bg-accent px-8 py-3.5 text-sm font-semibold text-bg transition-colors hover:bg-accent-hover"
           >
-            Explore Services
+            {HERO_TEXT.cta.primary}
           </MagneticButton>
           <MagneticButton
             href="#projects"
             className="rounded-full border border-border px-8 py-3.5 text-sm font-semibold text-text-primary transition-colors hover:border-border-light hover:bg-surface-1"
           >
-            View Projects
+            {HERO_TEXT.cta.secondary}
           </MagneticButton>
         </motion.div>
 
@@ -100,14 +101,14 @@ export const Hero = () => (
           className="mt-20 flex items-center gap-2 text-text-muted"
         >
           <ArrowDown size={16} className="animate-bounce" />
-          <span className="font-mono text-xs tracking-wider">SCROLL</span>
+          <span className="font-mono text-xs tracking-wider">{HERO_TEXT.scroll.toUpperCase()}</span>
         </motion.div>
       </div>
 
       {/* Side label — decorative, desktop only */}
       <div className="absolute right-6 top-1/2 hidden -translate-y-1/2 -rotate-90 md:block">
         <span className="font-mono text-xs tracking-[0.3em] text-text-muted/50">
-          EST. 2024 — {SITE_CONFIG.domain}
+          EST. {HERO_TEXT.established} — {SITE_CONFIG.domain}
         </span>
       </div>
     </div>

--- a/src/components/json-ld.tsx
+++ b/src/components/json-ld.tsx
@@ -11,19 +11,7 @@ const organizationSchema = {
   description: SITE_CONFIG.description,
   email: SITE_CONFIG.email,
   sameAs: [SITE_CONFIG.github, SITE_CONFIG.telegram],
-  knowsAbout: [
-    "DevOps",
-    "Docker",
-    "CI/CD",
-    "AI Integration",
-    "LLM Deployment",
-    "Embedded Systems",
-    "IoT",
-    "Web Development",
-    "React",
-    "Next.js",
-    "TypeScript",
-  ],
+  knowsAbout: [...new Set(SERVICES.flatMap((s) => [...s.tags]))],
 };
 
 const websiteSchema = {

--- a/src/components/projects.tsx
+++ b/src/components/projects.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from "framer-motion";
 import { PROJECTS } from "@/lib/site-config";
+import { EASE_OUT_EXPO } from "@/lib/motion";
 import { SectionHeading } from "@/components/ui/section-heading";
 
 const STATUS_STYLES = {
@@ -14,7 +15,7 @@ const ROW_VARIANTS = {
   visible: (i: number) => ({
     opacity: 1,
     x: 0,
-    transition: { delay: 0.08 * i, duration: 0.5, ease: [0.16, 1, 0.3, 1] as const },
+    transition: { delay: 0.08 * i, duration: 0.5, ease: EASE_OUT_EXPO },
   }),
 };
 

--- a/src/components/services.tsx
+++ b/src/components/services.tsx
@@ -2,6 +2,7 @@
 
 import { motion } from "framer-motion";
 import { SERVICES } from "@/lib/site-config";
+import { EASE_OUT_EXPO } from "@/lib/motion";
 import { SectionHeading } from "@/components/ui/section-heading";
 import { SERVICE_ICON_MAP } from "@/components/ui/icons";
 
@@ -10,7 +11,7 @@ const CARD_VARIANTS = {
   visible: (i: number) => ({
     opacity: 1,
     y: 0,
-    transition: { delay: 0.1 * i, duration: 0.5, ease: [0.16, 1, 0.3, 1] as const },
+    transition: { delay: 0.1 * i, duration: 0.5, ease: EASE_OUT_EXPO },
   }),
 };
 

--- a/src/components/ui/icons.tsx
+++ b/src/components/ui/icons.tsx
@@ -1,4 +1,5 @@
 import type { SVGProps } from "react";
+import type { SERVICES } from "@/lib/site-config";
 
 type IconProps = SVGProps<SVGSVGElement>;
 
@@ -57,8 +58,10 @@ export const TelegramIcon = (props: IconProps) => (
   </svg>
 );
 
-/** Map service IDs to icon components */
-export const SERVICE_ICON_MAP: Record<string, React.ReactNode> = {
+type ServiceId = (typeof SERVICES)[number]["id"];
+
+/** Map service IDs to icon components — type-safe, errors if a service is missing */
+export const SERVICE_ICON_MAP: Record<ServiceId, React.ReactNode> = {
   devops: <DevOpsIcon />,
   ai: <AiIcon />,
   embedded: <EmbeddedIcon />,

--- a/src/components/ui/magnetic-button.tsx
+++ b/src/components/ui/magnetic-button.tsx
@@ -7,6 +7,8 @@ interface MagneticButtonProps {
   href?: string;
   className?: string;
   strength?: number;
+  target?: string;
+  rel?: string;
 }
 
 export const MagneticButton = ({
@@ -14,6 +16,8 @@ export const MagneticButton = ({
   href,
   className = "",
   strength = 0.15,
+  target,
+  rel,
 }: MagneticButtonProps) => {
   const ref = useRef<HTMLAnchorElement | HTMLButtonElement>(null);
 
@@ -38,7 +42,7 @@ export const MagneticButton = ({
 
   if (href) {
     return (
-      <a ref={ref as React.RefObject<HTMLAnchorElement>} href={href} {...props}>
+      <a ref={ref as React.RefObject<HTMLAnchorElement>} href={href} target={target} rel={rel} {...props}>
         {children}
       </a>
     );

--- a/src/lib/motion.ts
+++ b/src/lib/motion.ts
@@ -1,0 +1,2 @@
+/** Shared easing curve — expo out, used across all scroll animations */
+export const EASE_OUT_EXPO = [0.16, 1, 0.3, 1] as const;

--- a/src/lib/site-config.ts
+++ b/src/lib/site-config.ts
@@ -95,6 +95,15 @@ export const ABOUT_TEXT = {
   ],
 } as const;
 
+export const HERO_TEXT = {
+  badge: "Engineering Studio",
+  headline: ["We build what", "others outsource"],
+  cta: { primary: "Explore Services", secondary: "View Projects" },
+  ctaContact: "Get in Touch",
+  scroll: "Scroll",
+  established: 2024,
+} as const;
+
 export const CONTACT_TEXT = {
   label: "Let's talk",
   headline: "Have a project in mind?",


### PR DESCRIPTION
Closes #41, #42, #43, #44, #45, #46, #47, #48, #49, #50, #51

## Critical

### #41 — OG image: SVG → auto-generated PNG
- NEW: `src/app/opengraph-image.tsx` — uses Next.js convention to auto-generate PNG (1200x630)
- All content from site-config (name, tagline, services)
- Removed manual `images` refs from layout.tsx metadata (convention handles it)
- SVG was unsupported by Twitter, Facebook, Slack, Discord, LinkedIn

## Architecture & Type Safety

### #42 — Hardcoded strings → site-config
- NEW: `HERO_TEXT` in site-config with badge, headline, CTAs, scroll, established year
- `hero.tsx` — all 6 hardcoded strings replaced with config values
- `header.tsx` — "Get in Touch" replaced with `HERO_TEXT.ctaContact` (desktop + mobile)

### #45 — SERVICE_ICON_MAP strict typing
- Changed from `Record<string, ReactNode>` to `Record<ServiceId, ReactNode>`
- `ServiceId` derived from `(typeof SERVICES)[number]["id"]`
- TypeScript now errors if a new service is added without a matching icon

### #48 — Shared animation easing
- NEW: `src/lib/motion.ts` with `EASE_OUT_EXPO = [0.16, 1, 0.3, 1]`
- Replaced in 5 files: hero, services, projects, about, contact

## Performance

### #43 — useActiveSection observer leak
- `NAV_LINKS.map()` created new array every render → IntersectionObserver recreated
- Fix: `useMemo(() => NAV_LINKS.map(...), [])` in header.tsx

## Security

### #44 — MagneticButton external link security
- Added `target` and `rel` props to MagneticButtonProps
- Forwarded to `<a>` element
- Added `target="_blank" rel="noopener noreferrer"` to Telegram link in contact.tsx

### #46 — Security headers
- `next.config.ts`: X-Frame-Options DENY, X-Content-Type-Options nosniff, HSTS, Referrer-Policy, Permissions-Policy

## Accessibility

### #47 — Mobile menu
- Added `aria-expanded={mobileOpen}` to toggle button
- Added Escape key handler to close menu

## Data Consistency

### #49 — noscript uses config
- Replaced hardcoded text with `SITE_CONFIG` and `SERVICES` values
- Replaced hardcoded `#fafafa` with `var(--text-primary)`

### #50 — API cache + CORS
- `/api/site-summary` now returns `Cache-Control: public, s-maxage=3600` and `Access-Control-Allow-Origin: *`

### #51 — JSON-LD knowsAbout
- Derived from `SERVICES.flatMap(s => s.tags)` instead of hardcoded array

## Verified
- `tsc --noEmit` — 0 errors