### PR TITLE
chore: v0.3.1 — version bump + changelog

### DIFF
--- a/.github/banner.svg
+++ b/.github/banner.svg
@@ -40,7 +40,7 @@
   <rect x="406" y="230" width="114" height="28" rx="14" fill="#111113" stroke="#27272a" stroke-width="1"/>
   <text x="418" y="249" font-family="monospace" font-size="11" fill="#a1a1aa">Framer Motion</text>
   <!-- version -->
-  <text x="60" y="295" font-family="monospace" font-size="11" letter-spacing="1.5" fill="#71717a">v0.3.0</text>
+  <text x="60" y="295" font-family="monospace" font-size="11" letter-spacing="1.5" fill="#71717a">v0.3.1</text>
   <!-- side decoration -->
   <line x1="840" y1="60" x2="840" y2="260" stroke="#27272a" stroke-width="1" stroke-dasharray="4 4"/>
   <text x="855" y="168" font-family="monospace" font-size="9" letter-spacing="3" fill="#3f3f46" transform="rotate(90, 855, 168)">essentialhustle.dev</text>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,23 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.3.1] - 2025-02-25
+
+### Fixed
+- OG image: SVG → auto-generated PNG via opengraph-image.tsx (SVG unsupported by social platforms)
+- MagneticButton: external links now support target/rel (Telegram link was missing noopener)
+- useActiveSection: memoized sectionHrefs to prevent IntersectionObserver recreation every render
+- Mobile menu: added aria-expanded and Escape key handler
+- noscript fallback: replaced hardcoded text with site-config values
+
+### Changed
+- SERVICE_ICON_MAP: strict ServiceId typing — TypeScript errors if icon missing for a service
+- Hardcoded hero/header strings moved to HERO_TEXT in site-config
+- Animation easing extracted to shared EASE_OUT_EXPO constant (was duplicated in 5 files)
+- JSON-LD knowsAbout derived from SERVICES tags instead of hardcoded array
+- /api/site-summary: added Cache-Control + CORS headers
+- Security headers added via next.config.ts (X-Frame-Options, HSTS, CSP, Referrer-Policy)
+
 ## [0.3.0] - 2025-02-25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "essential-hustle",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Version bump 0.3.0 → 0.3.1. Banner SVG synced. CHANGELOG updated.