### PR TITLE
fix: code review round 2 — button type, next/link, skip nav (#54-#56)

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -66,6 +66,12 @@ export default function RootLayout({
       <body
         className={`${spaceGrotesk.variable} ${inter.variable} ${jetbrainsMono.variable} grain antialiased`}
       >
+        <a
+          href="#main"
+          className="sr-only focus:not-sr-only focus:fixed focus:top-4 focus:left-4 focus:z-[60] focus:rounded-lg focus:bg-accent focus:px-4 focus:py-2 focus:text-bg focus:text-sm focus:font-semibold"
+        >
+          Skip to content
+        </a>
         <noscript>
           <div style={{ padding: "2rem", color: "var(--text-primary)", fontFamily: "system-ui" }}>
             <h1>{SITE_CONFIG.name} — {SITE_CONFIG.tagline}</h1>

--- a/src/app/not-found.tsx
+++ b/src/app/not-found.tsx
@@ -1,3 +1,4 @@
+import Link from "next/link";
 import { SITE_CONFIG } from "@/lib/site-config";
 
 export default function NotFound() {
@@ -10,12 +11,12 @@ export default function NotFound() {
       <p className="mt-4 max-w-md text-center text-lg text-text-secondary">
         This page doesn&apos;t exist. Maybe the URL is wrong, or the page was moved.
       </p>
-      <a
+      <Link
         href="/"
         className="mt-8 rounded-full bg-accent px-8 py-3.5 text-sm font-semibold text-bg transition-colors hover:bg-accent-hover"
       >
         Back to {SITE_CONFIG.name}
-      </a>
+      </Link>
     </div>
   );
 }

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -11,7 +11,7 @@ export default function Home() {
   return (
     <>
       <Header />
-      <main>
+      <main id="main">
         <Hero />
         <SectionDivider />
         <Services />

--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -57,6 +57,7 @@ export const Header = () => {
 
         {/* Mobile toggle */}
         <button
+          type="button"
           onClick={() => setMobileOpen(!mobileOpen)}
           className="text-text-secondary md:hidden"
           aria-label="Toggle menu"


### PR DESCRIPTION
Closes #54, #55, #56

### #54 — Header toggle button type
Added `type="button"` — was defaulting to `submit`

### #55 — not-found.tsx: next/link
Replaced raw `<a href="/">` with `<Link href="/">` — fixes ESLint error, enables client-side routing

### #56 — Skip-to-content link (WCAG 2.4.1)
- Added visually-hidden skip link as first element in `<body>` (layout.tsx)
- Added `id="main"` to `<main>` element (page.tsx)
- Shows on focus with accent styling at z-60

### Verified
- `tsc --noEmit` — 0 errors
- `eslint src/` — 0 errors (was 1 before)
- `next build` — passes