### PR TITLE
feat: Umami self-hosted analytics (#66)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -4,5 +4,6 @@
 # Contact email (displayed on site)
 NEXT_PUBLIC_CONTACT_EMAIL=hello@essentialhustle.dev
 
-# Analytics (optional)
-# NEXT_PUBLIC_GA_ID=G-XXXXXXXXXX
+# Umami Analytics (optional — self-hosted)
+# NEXT_PUBLIC_UMAMI_URL=https://analytics.essentialhustle.dev
+# NEXT_PUBLIC_UMAMI_WEBSITE_ID=your-website-id

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -3,6 +3,7 @@ import { Space_Grotesk, Inter, JetBrains_Mono } from "next/font/google";
 import { SITE_CONFIG, SERVICES } from "@/lib/site-config";
 import { Providers } from "@/components/providers";
 import { JsonLd } from "@/components/json-ld";
+import { Analytics } from "@/components/analytics";
 import "./globals.css";
 
 const spaceGrotesk = Space_Grotesk({
@@ -81,6 +82,7 @@ export default function RootLayout({
           </div>
         </noscript>
         <Providers>{children}</Providers>
+        <Analytics />
       </body>
     </html>
   );

--- a/src/components/analytics.tsx
+++ b/src/components/analytics.tsx
@@ -1,0 +1,21 @@
+import Script from "next/script";
+
+const UMAMI_URL = process.env.NEXT_PUBLIC_UMAMI_URL;
+const WEBSITE_ID = process.env.NEXT_PUBLIC_UMAMI_WEBSITE_ID;
+
+/**
+ * Umami analytics script — only renders when env vars are set.
+ * Privacy-friendly, no cookies, GDPR compliant.
+ */
+export const Analytics = () => {
+  if (!UMAMI_URL || !WEBSITE_ID) return null;
+
+  return (
+    <Script
+      async
+      src={`${UMAMI_URL}/script.js`}
+      data-website-id={WEBSITE_ID}
+      strategy="afterInteractive"
+    />
+  );
+};


### PR DESCRIPTION
Closes #66

## Infrastructure (already deployed)
- Umami Docker on Ubuntu (127.0.0.1:3001)
- Autossh tunnel → VPS localhost:3002
- Nginx reverse proxy: https://analytics.essentialhustle.dev
- SSL via Let's Encrypt (auto-renew)
- DNS A record added via Dynadot API

## Code changes
- `src/components/analytics.tsx` — conditional Umami script (only loads when env vars set)
- `src/app/layout.tsx` — Analytics component added before closing body
- `.env.example` — updated with UMAMI_URL and WEBSITE_ID vars

## Verified
- tsc --noEmit — 0 errors
- eslint src/ — 0 errors
- https://analytics.essentialhustle.dev — 200 OK