### PR TITLE
chore: v0.5.0 — version bump + changelog

### DIFF
--- a/.github/banner.svg
+++ b/.github/banner.svg
@@ -40,7 +40,7 @@
   <rect x="406" y="230" width="114" height="28" rx="14" fill="#111113" stroke="#27272a" stroke-width="1"/>
   <text x="418" y="249" font-family="monospace" font-size="11" fill="#a1a1aa">Framer Motion</text>
   <!-- version -->
-  <text x="60" y="295" font-family="monospace" font-size="11" letter-spacing="1.5" fill="#71717a">v0.4.0</text>
+  <text x="60" y="295" font-family="monospace" font-size="11" letter-spacing="1.5" fill="#71717a">v0.5.0</text>
   <!-- side decoration -->
   <line x1="840" y1="60" x2="840" y2="260" stroke="#27272a" stroke-width="1" stroke-dasharray="4 4"/>
   <text x="855" y="168" font-family="monospace" font-size="9" letter-spacing="3" fill="#3f3f46" transform="rotate(90, 855, 168)">essentialhustle.dev</text>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,29 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.0] - 2025-02-25
+
+### Added
+- **Blog** with MDX support (`/blog`, `/blog/[slug]`)
+  - File-based content engine (gray-matter + next-mdx-remote + rehype-pretty-code)
+  - Custom MDX components (typography, code blocks, external links)
+  - RSS feed at `/feed.xml`
+  - JSON-LD BlogPosting schema per post
+  - Sitemap updated with blog index + all posts
+  - 2 sample posts: Ollama on consumer GPUs, Docker Compose patterns
+- **Contact form** with Zod validation and Server Action
+  - Name, email, message fields with field-level errors
+  - In-memory rate limiting (1/min per email)
+  - Configurable webhook via `CONTACT_WEBHOOK_URL` env var
+- **Testimonials** section with quote cards and stagger animation
+- Blog link in navigation (next/link for client-side routing)
+- RSS `<link>` tag in document head
+
+### Changed
+- Header handles both anchor (`#`) and page (`/`) links
+- `useActiveSection` filters only anchor hrefs
+- Dependencies: gray-matter, next-mdx-remote, rehype-pretty-code, shiki, reading-time, zod
+
 ## [0.4.0] - 2025-02-25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "essential-hustle",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
Version bump 0.4.0 → 0.5.0. Banner SVG synced. CHANGELOG updated.