### PR TITLE
fix: ThemeToggle SSR hang — never-resolving Promise (#86)

### DIFF
--- a/src/components/ui/theme-toggle.tsx
+++ b/src/components/ui/theme-toggle.tsx
@@ -1,19 +1,16 @@
 "use client";
 
+import { useState, useEffect } from "react";
 import { useTheme } from "next-themes";
 import { Sun, Moon } from "lucide-react";
-import { use } from "react";
-
-/** Resolves after first client render — avoids useEffect + setState lint warning */
-const mountPromise = typeof window !== "undefined"
-  ? Promise.resolve(true)
-  : new Promise<boolean>(() => {});
 
 export const ThemeToggle = () => {
   const { resolvedTheme, setTheme } = useTheme();
-  const mounted = use(mountPromise);
+  const [mounted, setMounted] = useState(false);
 
-  // Prevent hydration mismatch — render placeholder on server
+  useEffect(() => setMounted(true), []);
+
+  // Prevent hydration mismatch — render placeholder until client mount
   if (!mounted) {
     return <div className="h-9 w-9" />;
   }


### PR DESCRIPTION
## Root Cause
`ThemeToggle` used `React.use()` with a Promise that **never resolves on the server**:
```ts
new Promise<boolean>(() => {}) // hangs SSR forever
```

## Fix
Standard `useEffect + useState` mount detection.

## Results
| Route | Before | After |
|-------|--------|-------|
| `/` | 87s (timeout) | 0.04s |
| `/ru` | 87s | 0.04s |
| `/blog` | 87s | 0.63s |

Closes #86