### PR TITLE
fix: raise header breakpoint from md to lg — tablet nav overflow

### DIFF
--- a/src/components/header.tsx
+++ b/src/components/header.tsx
@@ -54,7 +54,7 @@ export const Header = () => {
         </Link>
 
         {/* Desktop nav */}
-        <div className="hidden items-center gap-8 md:flex">
+        <div className="hidden items-center gap-8 lg:flex">
           {NAV_LINKS.map((link) =>
             isAnchor(link.href) ? (
               <a
@@ -87,7 +87,7 @@ export const Header = () => {
         </div>
 
         {/* Mobile: theme + menu toggle */}
-        <div className="flex items-center gap-2 md:hidden">
+        <div className="flex items-center gap-2 lg:hidden">
           <ThemeToggle />
           <button
             type="button"
@@ -108,7 +108,7 @@ export const Header = () => {
             initial={{ opacity: 0, height: 0 }}
             animate={{ opacity: 1, height: "auto" }}
             exit={{ opacity: 0, height: 0 }}
-            className="border-t border-border/50 bg-bg/95 backdrop-blur-xl md:hidden"
+            className="border-t border-border/50 bg-bg/95 backdrop-blur-xl lg:hidden"
           >
             <div className="flex flex-col gap-4 px-6 py-6">
               {NAV_LINKS.map((link) =>


### PR DESCRIPTION
## Что изменено
Поднят breakpoint мобильного меню с `md` (768px) до `lg` (1024px). На tablet (768-1023px) теперь показывается hamburger menu вместо сжатого desktop nav.

## Тип изменения
- [x] fix — баг-фикс

## Чеклист
- [x] Код соответствует уровню Strong Senior
- [x] `tsc --noEmit` без ошибок
- [x] `npm run lint` без ошибок
- [x] Визуально проверено: 375px, 768px, 1024px, 1440px — всё ОК
- [x] `.env.example` актуален

## Связанные Issues
Closes #115