### PR TITLE
fix: Dockerfile — copy @swc/helpers to standalone output

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -28,10 +28,11 @@ ENV PORT=3000
 RUN addgroup --system --gid 1001 nodejs && \
     adduser --system --uid 1001 nextjs
 
-# Copy standalone output + static assets
+# Copy standalone output + static assets + missing node_modules
 COPY --from=builder /app/public ./public
 COPY --from=builder --chown=nextjs:nodejs /app/.next/standalone ./
 COPY --from=builder --chown=nextjs:nodejs /app/.next/static ./.next/static
+COPY --from=builder /app/node_modules/@swc ./node_modules/@swc
 
 USER nextjs
 


### PR DESCRIPTION
## Что изменено
Next.js standalone output не включает `@swc/helpers` — runtime падает с `MODULE_NOT_FOUND`. Добавлен `COPY` для `node_modules/@swc` из builder stage.

## Тип изменения
- [x] fix — баг-фикс

## Чеклист
- [x] Код соответствует уровню Strong Senior
- [x] Docker build проверен на Ubuntu production server