### PR TITLE
chore: v0.8.1 — deployment fixes, security patches, repo governance

### DIFF
--- a/.github/banner.svg
+++ b/.github/banner.svg
@@ -40,7 +40,7 @@
   <rect x="406" y="230" width="114" height="28" rx="14" fill="#111113" stroke="#27272a" stroke-width="1"/>
   <text x="418" y="249" font-family="monospace" font-size="11" fill="#a1a1aa">Framer Motion</text>
   <!-- version -->
-  <text x="60" y="295" font-family="monospace" font-size="11" letter-spacing="1.5" fill="#71717a">v0.8.0</text>
+  <text x="60" y="295" font-family="monospace" font-size="11" letter-spacing="1.5" fill="#71717a">v0.8.1</text>
   <!-- side decoration -->
   <line x1="840" y1="60" x2="840" y2="260" stroke="#27272a" stroke-width="1" stroke-dasharray="4 4"/>
   <text x="855" y="168" font-family="monospace" font-size="9" letter-spacing="3" fill="#3f3f46" transform="rotate(90, 855, 168)">essentialhustle.dev</text>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,24 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.8.1] - 2026-02-25
+
+### Fixed
+- **ThemeToggle ESLint** — replaced `useState+useEffect` mount detection with `useSyncExternalStore` (canonical React pattern) (#114)
+- **@swc/helpers conflict** — resolved version mismatch via `overrides` in package.json (#114)
+- **Lighthouse CI** — fixed config for standalone output, relaxed thresholds for CI runners (#114)
+- **Dockerfile** — copy `@swc/helpers` to standalone output (runtime MODULE_NOT_FOUND fix) (#118)
+- **Tablet header overflow** — raised mobile menu breakpoint from `md` (768px) to `lg` (1024px) (#115, #116)
+- **RSS feed XML injection** — added `escapeXml()` for category tags and `escapeCdata()` for CDATA sections (#117)
+
+### Added
+- **Production deployment** — site live at `https://essentialhustle.dev`
+- **Nginx reverse proxy** on VPS with SSL (Let's Encrypt)
+- **autossh tunnel** Ubuntu:3002 → VPS:3003
+
+### Changed
+- **Repo governance** — issue templates, PR template, CODEOWNERS, auto-labeler, 12 custom labels (#113)
+
 ## [0.8.0] - 2026-02-25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "essential-hustle",
-  "version": "0.8.0",
+  "version": "0.8.1",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Что изменено
Version bump v0.8.1 + CHANGELOG + banner sync.

## Тип изменения
- [x] chore — служебное

## Чеклист
- [x] Версия обновлена
- [x] CHANGELOG.md обновлён
- [x] Banner SVG синхронизирован