### PR TITLE
fix: disable locale detection (default EN) + healthcheck wget→node

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,6 @@ USER nextjs
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD wget --no-verbose --tries=1 --spider http://localhost:3000/ || exit 1
+  CMD node -e "fetch('http://localhost:3000/').then(r=>{process.exit(r.ok?0:1)}).catch(()=>process.exit(1))"
 
 CMD ["node", "server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     environment:
       - NODE_ENV=production
     healthcheck:
-      test: ["CMD", "wget", "--no-verbose", "--tries=1", "--spider", "http://localhost:3000/"]
+      test: ["CMD", "node", "-e", "fetch('http://localhost:3000/').then(r=>{process.exit(r.ok?0:1)}).catch(()=>process.exit(1))"]
       interval: 30s
       timeout: 5s
       start_period: 10s

--- a/src/i18n/routing.ts
+++ b/src/i18n/routing.ts
@@ -6,6 +6,7 @@ export const routing = defineRouting({
   locales,
   defaultLocale,
   localePrefix: "as-needed",
+  localeDetection: false,
 });
 
 export const { Link, redirect, usePathname, useRouter } =


### PR DESCRIPTION
## Что изменено
1. **Locale detection disabled** — `localeDetection: false` в routing config. Сайт всегда открывается на EN, пользователи переключают язык вручную через switcher.
2. **Healthcheck** — заменён `wget` на `node fetch` в Dockerfile и docker-compose.yml (wget отсутствует в standalone Alpine image).

## Тип изменения
- [x] fix — баг-фикс

## Чеклист
- [x] `tsc --noEmit` без ошибок
- [x] `npm run lint` без ошибок

## Связанные Issues
N/A