### PR TITLE
chore: v0.9.0 — Content & Conversion milestone

### DIFF
--- a/.github/banner.svg
+++ b/.github/banner.svg
@@ -40,7 +40,7 @@
   <rect x="406" y="230" width="114" height="28" rx="14" fill="#111113" stroke="#27272a" stroke-width="1"/>
   <text x="418" y="249" font-family="monospace" font-size="11" fill="#a1a1aa">Framer Motion</text>
   <!-- version -->
-  <text x="60" y="295" font-family="monospace" font-size="11" letter-spacing="1.5" fill="#71717a">v0.8.1</text>
+  <text x="60" y="295" font-family="monospace" font-size="11" letter-spacing="1.5" fill="#71717a">v0.9.0</text>
   <!-- side decoration -->
   <line x1="840" y1="60" x2="840" y2="260" stroke="#27272a" stroke-width="1" stroke-dasharray="4 4"/>
   <text x="855" y="168" font-family="monospace" font-size="9" letter-spacing="3" fill="#3f3f46" transform="rotate(90, 855, 168)">essentialhustle.dev</text>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,27 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.9.0] - 2026-02-25
+
+### Added
+- **Contact form email delivery** — nodemailer SMTP transport to `hello@essentialhustle.dev` with auto-reply to sender (#124)
+- **Telegram notifications** — instant Bot API notifications on contact form submission, fire-and-forget (#125)
+- **Case study detail pages** — `/projects/[slug]` with Challenge/Solution/Result sections, tech stack, timeline, navigation between projects (#126)
+- **Privacy Policy page** — `/privacy` with GDPR-compliant content, i18n (EN/RU/ZH) (#128)
+- **Terms of Service page** — `/terms` with i18n (EN/RU/ZH) (#128)
+- **Blog post** — "Next.js Standalone Output in Docker: Lessons from Production" (#130)
+- **Footer legal links** — Privacy Policy and Terms of Service in footer navigation
+- **Umami events** — `project-click`, `case-study-nav`, `case-study-back` tracking
+
+### Changed
+- **Projects section** — rows now link to case study detail pages with ArrowRight indicator
+- **Rate limiting** — hardened with IP + email fallback, 1 min sliding window
+
+### Security
+- **Email subject sanitization** — `sanitizeSubject()` strips control characters to prevent header injection
+- **SMTP timeouts** — 10s connection, 15s socket to prevent hanging requests
+- **Notification decoupled from auto-reply** — primary delivery determines success independently
+
 ## [0.8.1] - 2026-02-25
 
 ### Fixed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "essential-hustle",
-  "version": "0.8.1",
+  "version": "0.9.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Что изменено
Version bump v0.9.0 + CHANGELOG + banner sync.

## Milestone v0.9.0 — все issues закрыты
- #124 Contact form email delivery
- #125 Telegram notifications
- #126 Case study pages
- #127 Testimonials (already existed)
- #128 Legal pages (Privacy + Terms)
- #129 Custom 404 (already existed)
- #130 Blog content (3 articles)

## Тип изменения
- [x] chore — служебное