### PR TITLE
feat: convert README to fully SVG-based layout

### DIFF
--- a/.github/design.svg
+++ b/.github/design.svg
@@ -1,0 +1,72 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 220" fill="none">
+  <defs>
+    <pattern id="ddots" x="0" y="0" width="16" height="16" patternUnits="userSpaceOnUse">
+      <circle cx="8" cy="8" r="0.5" fill="#3f3f46" opacity="0.3"/>
+    </pattern>
+  </defs>
+
+  <!-- Color palette -->
+  <g transform="translate(0, 0)">
+    <rect width="440" height="100" rx="10" fill="#09090b" stroke="#27272a" stroke-width="1"/>
+    <rect width="440" height="100" rx="10" fill="url(#ddots)"/>
+    <rect x="20" y="20" width="18" height="18" rx="4" fill="#09090b" stroke="#f97316" stroke-width="1.5"/>
+    <rect x="24" y="24" width="10" height="10" rx="2" fill="#f97316" opacity="0.4"/>
+    <text x="50" y="35" font-family="monospace" font-size="12" letter-spacing="2" fill="#f97316">COLOR</text>
+    <text x="20" y="58" font-family="system-ui, sans-serif" font-size="12" fill="#a1a1aa">Base </text>
+    <text x="50" y="58" font-family="monospace" font-size="11" fill="#71717a">#09090b</text>
+    <text x="120" y="58" font-family="system-ui, sans-serif" font-size="12" fill="#a1a1aa"> — almost black but not void.</text>
+    <text x="20" y="78" font-family="system-ui, sans-serif" font-size="12" fill="#a1a1aa">Orange </text>
+    <text x="68" y="78" font-family="monospace" font-size="11" fill="#f97316">#f97316</text>
+    <text x="136" y="78" font-family="system-ui, sans-serif" font-size="12" fill="#a1a1aa"> + cyan </text>
+    <text x="182" y="78" font-family="monospace" font-size="11" fill="#06b6d4">#06b6d4</text>
+    <text x="250" y="78" font-family="system-ui, sans-serif" font-size="12" fill="#a1a1aa"> — opposite ends.</text>
+  </g>
+
+  <!-- Typography -->
+  <g transform="translate(460, 0)">
+    <rect width="440" height="100" rx="10" fill="#09090b" stroke="#27272a" stroke-width="1"/>
+    <rect width="440" height="100" rx="10" fill="url(#ddots)"/>
+    <g transform="translate(20, 20)" stroke="#06b6d4" stroke-width="1.5" stroke-linecap="round" fill="none">
+      <path d="M4 20L12 4L20 20"/>
+      <path d="M7 14h10"/>
+    </g>
+    <text x="50" y="35" font-family="monospace" font-size="12" letter-spacing="2" fill="#06b6d4">TYPOGRAPHY</text>
+    <text x="20" y="58" font-family="system-ui, sans-serif" font-weight="600" font-size="12" fill="#a1a1aa">Space Grotesk</text>
+    <text x="130" y="58" font-family="system-ui, sans-serif" font-size="11" fill="#71717a">headlines — geometric, wide</text>
+    <text x="20" y="74" font-family="system-ui, sans-serif" font-size="12" fill="#a1a1aa">Inter</text>
+    <text x="52" y="74" font-family="system-ui, sans-serif" font-size="11" fill="#71717a">body — neutral, disappears</text>
+    <text x="20" y="90" font-family="monospace" font-size="12" fill="#a1a1aa">JetBrains Mono</text>
+    <text x="144" y="90" font-family="system-ui, sans-serif" font-size="11" fill="#71717a">tags, code — signals "technical"</text>
+  </g>
+
+  <!-- Layout hero -->
+  <g transform="translate(0, 116)">
+    <rect width="440" height="100" rx="10" fill="#09090b" stroke="#27272a" stroke-width="1"/>
+    <rect width="440" height="100" rx="10" fill="url(#ddots)"/>
+    <g transform="translate(20, 20)" stroke="#f97316" stroke-width="1.5" stroke-linecap="round" fill="none">
+      <rect x="2" y="2" width="20" height="20" rx="3"/>
+      <path d="M7 7h10M7 12h6M7 17h8"/>
+    </g>
+    <text x="50" y="35" font-family="monospace" font-size="12" letter-spacing="2" fill="#f97316">LAYOUT</text>
+    <text x="20" y="58" font-family="system-ui, sans-serif" font-size="12" fill="#a1a1aa">Hero is asymmetric — content left, side label at</text>
+    <text x="20" y="74" font-family="monospace" font-size="11" fill="#71717a">rotate(-90deg)</text>
+    <text x="128" y="74" font-family="system-ui, sans-serif" font-size="12" fill="#a1a1aa">floating right.</text>
+    <text x="20" y="90" font-family="system-ui, sans-serif" font-size="12" fill="#a1a1aa">Services: 2×2 bento grid. Projects: editorial rows.</text>
+  </g>
+
+  <!-- Animations -->
+  <g transform="translate(460, 116)">
+    <rect width="440" height="100" rx="10" fill="#09090b" stroke="#27272a" stroke-width="1"/>
+    <rect width="440" height="100" rx="10" fill="url(#ddots)"/>
+    <g transform="translate(20, 18)" stroke="#06b6d4" stroke-width="1.5" stroke-linecap="round" fill="none">
+      <circle cx="12" cy="12" r="10"/>
+      <path d="M12 6v6l4 2"/>
+    </g>
+    <text x="50" y="35" font-family="monospace" font-size="12" letter-spacing="2" fill="#06b6d4">MOTION</text>
+    <text x="20" y="58" font-family="system-ui, sans-serif" font-size="12" fill="#a1a1aa">Framer Motion — stagger reveals, viewport-triggered.</text>
+    <text x="20" y="74" font-family="system-ui, sans-serif" font-size="12" fill="#a1a1aa">Magnetic buttons via </text>
+    <text x="174" y="74" font-family="monospace" font-size="11" fill="#71717a">mousemove</text>
+    <text x="252" y="74" font-family="system-ui, sans-serif" font-size="12" fill="#a1a1aa"> offset — no library.</text>
+    <text x="20" y="90" font-family="system-ui, sans-serif" font-size="12" fill="#a1a1aa">Grain: feTurbulence SVG filter, opacity 0.03.</text>
+  </g>
+</svg>

--- a/.github/intro.svg
+++ b/.github/intro.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 100" fill="none">
+  <rect width="900" height="100" rx="10" fill="#09090b" stroke="#27272a" stroke-width="1"/>
+  <text x="40" y="30" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#a1a1aa">Hand-built site for an engineering studio that ships infrastructure,</text>
+  <text x="40" y="50" font-family="system-ui, -apple-system, sans-serif" font-size="14" fill="#a1a1aa">AI pipelines, embedded firmware, and web applications.</text>
+  <text x="40" y="76" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#71717a">No templates. No page builders. Every icon, animation, and layout — from scratch.</text>
+  <text x="810" y="30" font-family="monospace" font-size="11" fill="#f97316">i18n</text>
+  <text x="790" y="50" font-family="monospace" font-size="9" fill="#52525b">EN · RU · ZH</text>
+  <text x="790" y="74" font-family="monospace" font-size="9" fill="#52525b">SSG · Docker</text>
+</svg>

--- a/.github/license.svg
+++ b/.github/license.svg
@@ -1,0 +1,9 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 50" fill="none">
+  <rect width="900" height="50" rx="10" fill="#09090b" stroke="#27272a" stroke-width="1"/>
+  <g transform="translate(20, 14)" stroke="#71717a" stroke-width="1.5" stroke-linecap="round" fill="none">
+    <rect x="2" y="2" width="18" height="18" rx="3"/>
+    <path d="M7 10h8M7 14h5"/>
+  </g>
+  <text x="50" y="28" font-family="monospace" font-size="12" letter-spacing="2" fill="#71717a">MIT</text>
+  <text x="90" y="28" font-family="system-ui, -apple-system, sans-serif" font-size="13" fill="#52525b">— do whatever you want with it.</text>
+</svg>

--- a/.github/run-locally.svg
+++ b/.github/run-locally.svg
@@ -1,0 +1,23 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 900 160" fill="none">
+  <rect width="900" height="160" rx="10" fill="#09090b" stroke="#27272a" stroke-width="1"/>
+
+  <!-- Terminal window -->
+  <rect x="30" y="16" width="540" height="128" rx="8" fill="#0a0a0f" stroke="#27272a" stroke-width="1"/>
+  <circle cx="50" cy="32" r="4" fill="#ef4444" opacity="0.6"/>
+  <circle cx="64" cy="32" r="4" fill="#eab308" opacity="0.6"/>
+  <circle cx="78" cy="32" r="4" fill="#22c55e" opacity="0.6"/>
+  <text x="50" y="60" font-family="monospace" font-size="12" fill="#52525b">$ </text><text x="66" y="60" font-family="monospace" font-size="12" fill="#a1a1aa">git clone https://github.com/</text>
+  <text x="66" y="78" font-family="monospace" font-size="12" fill="#a1a1aa">  Call-me-Boris-The-Razor/essential-hustle.git</text>
+  <text x="50" y="100" font-family="monospace" font-size="12" fill="#52525b">$ </text><text x="66" y="100" font-family="monospace" font-size="12" fill="#a1a1aa">npm install</text>
+  <text x="50" y="122" font-family="monospace" font-size="12" fill="#52525b">$ </text><text x="66" y="122" font-family="monospace" font-size="12" fill="#22c55e">npm run dev</text>
+  <circle cx="160" cy="122" r="4" fill="#22c55e" opacity="0.4"/>
+
+  <!-- Requirements -->
+  <rect x="600" y="16" width="270" height="128" rx="8" fill="#0a0a0f" stroke="#27272a" stroke-width="1"/>
+  <text x="620" y="38" font-family="monospace" font-size="9" fill="#52525b" letter-spacing="2">REQUIREMENTS</text>
+  <text x="620" y="60" font-family="monospace" font-size="11" fill="#a1a1aa">Node >= 22</text>
+  <text x="620" y="78" font-family="monospace" font-size="11" fill="#71717a">localhost:3000</text>
+  <text x="620" y="102" font-family="monospace" font-size="9" fill="#52525b" letter-spacing="2">VERSION SYNC</text>
+  <text x="620" y="120" font-family="monospace" font-size="11" fill="#a1a1aa">npm run version:sync</text>
+  <text x="620" y="136" font-family="monospace" font-size="9" fill="#52525b">auto via pre-commit hook</text>
+</svg>

--- a/README.md
+++ b/README.md
@@ -3,13 +3,10 @@
 </picture>
 
 <br />
-<br />
 
-We don't use templates. We don't use page builders.
-This is a hand-built site for an engineering studio that ships
-infrastructure, AI pipelines, embedded firmware, and web apps.
-
-Every pixel, every icon, every animation — written from scratch.
+<picture>
+  <img src=".github/intro.svg" alt="Hand-built site for an engineering studio" width="100%" />
+</picture>
 
 <br />
 
@@ -49,21 +46,9 @@ Every pixel, every icon, every animation — written from scratch.
 
 <br />
 
-Dark base is `#09090b` — almost black but not quite.
-Pure black (`#000`) feels like a hole in the screen. This has just enough warmth.
-
-Orange `#f97316` paired with cyan `#06b6d4`. Warm energy against cold tech.
-Two accents from opposite ends of the spectrum — same hue family
-and the whole thing would look monotone.
-
-Three typefaces, three jobs.
-**Space Grotesk** for headlines — geometric, techy, wide.
-**Inter** for body — neutral, readable, disappears.
-**JetBrains Mono** for tags and code — monospace signals "this is technical" without saying it.
-
-Hero is asymmetric on purpose. Content pushes left, a rotated side label floats
-right at `rotate(-90deg)`. Services are a `2×2` bento grid, not a list.
-Projects are editorial numbered rows — not cards, because cards all look the same.
+<picture>
+  <img src=".github/design.svg" alt="Color · Typography · Layout · Motion" width="100%" />
+</picture>
 
 <br />
 
@@ -79,17 +64,9 @@ Projects are editorial numbered rows — not cards, because cards all look the s
 
 <br />
 
-```bash
-git clone https://github.com/Call-me-Boris-The-Razor/essential-hustle.git
-cd essential-hustle
-npm install
-npm run dev
-```
-
-Node >= 22. Opens at `localhost:3000`.
-
-Version in the banner SVG syncs from `package.json` automatically via pre-commit hook.
-Manual: `npm run version:sync`.
+<picture>
+  <img src=".github/run-locally.svg" alt="git clone, npm install, npm run dev" width="100%" />
+</picture>
 
 <br />
 
@@ -105,4 +82,6 @@ Manual: `npm run version:sync`.
 
 <br />
 
-MIT — do whatever you want with it.
+<picture>
+  <img src=".github/license.svg" alt="MIT License" width="100%" />
+</picture>


### PR DESCRIPTION
## Что изменено

README.md конвертирован в полностью SVG-based формат — как в sortina-client. Весь текст теперь внутри SVG, никакого raw markdown.

### Новые SVGs
- `intro.svg` — описание проекта (3 строки + метаданные i18n/SSG)
- `design.svg` — 4 карточки: Color, Typography, Layout, Motion
- `run-locally.svg` — терминал с командами + requirements
- `license.svg` — MIT в одну строку

### Удалено
- Все raw markdown текст из README.md
- Code block с bash-командами
- Inline описание дизайна

## Тип изменения
- [x] feat — новый функционал

## Чеклист
- [x] Все SVG валидны
- [x] Zero raw text в README
- [x] `tsc --noEmit` без ошибок
- [x] Тексты только на английском

## Связанные Issues
Closes #143