### PR TITLE
security: add honeypot hidden field to contact form

### DIFF
--- a/src/app/actions/contact.ts
+++ b/src/app/actions/contact.ts
@@ -39,7 +39,16 @@ const isRateLimited = (clientId: string): boolean => {
   return false;
 };
 
-export async function submitContact(data: ContactFormData): Promise<ActionResult> {
+export async function submitContact(
+  data: ContactFormData,
+  honeypot?: string,
+): Promise<ActionResult> {
+  // Honeypot — bots fill this hidden field, humans don't
+  if (honeypot) {
+    // Silently accept to not reveal detection
+    return { success: true };
+  }
+
   // Validate
   const parsed = contactSchema.safeParse(data);
   if (!parsed.success) {

--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -48,8 +48,9 @@ export const ContactForm = () => {
     }
 
     setFieldErrors({});
+    const honeypot = (formData.get("website") as string) || undefined;
     startTransition(async () => {
-      const result = await submitContact(parsed.data);
+      const result = await submitContact(parsed.data, honeypot);
       if (result.success) {
         setState("success");
         (e.target as HTMLFormElement).reset();
@@ -82,6 +83,16 @@ export const ContactForm = () => {
 
   return (
     <form onSubmit={handleSubmit} className="mx-auto mt-10 max-w-md space-y-4 text-left">
+      {/* Honeypot — hidden from humans, traps bots that auto-fill all fields */}
+      <input
+        type="text"
+        name="website"
+        autoComplete="off"
+        tabIndex={-1}
+        aria-hidden="true"
+        className="absolute -left-[9999px] h-0 w-0 opacity-0"
+      />
+
       <div>
         <label htmlFor="contact-name" className="mb-1 block text-sm font-medium text-text-secondary">
           {t("name")}


### PR DESCRIPTION
## Что изменено

Добавлен honeypot — скрытое поле для ловли ботов. Завершает реализацию #133.

### Rate limiting checklist (всё из #133)
- [x] Rate limiter blocks excessive submissions (60s sliding window, IP-based)
- [x] User-friendly rate limit message in UI (i18n: EN/RU/ZH)
- [x] **Honeypot hidden field rejects bots** ← this PR
- [x] No external dependencies

### Как работает honeypot
1. Невидимое поле `website` добавлено в форму (`opacity-0`, `position: absolute`, `tabIndex={-1}`)
2. Реальные пользователи его не видят и не заполняют
3. Боты автоматически заполняют все поля формы
4. Если `website` заполнен → сервер возвращает `{ success: true }` (не раскрывая детекцию)

## Тип изменения
- [x] security — безопасность

## Связанные Issues
Closes #133