### PR TITLE
a11y: accessibility audit fixes — focus indicators, ARIA, screen reader support

### DIFF
--- a/src/app/globals.css
+++ b/src/app/globals.css
@@ -77,6 +77,13 @@ html {
   background-image: url("data:image/svg+xml,%3Csvg viewBox='0 0 256 256' xmlns='http://www.w3.org/2000/svg'%3E%3Cfilter id='noise'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.65' numOctaves='3' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23noise)'/%3E%3C/svg%3E");
 }
 
+/* Global focus-visible indicator for keyboard users */
+:focus-visible {
+  outline: 2px solid var(--accent);
+  outline-offset: 2px;
+  border-radius: 4px;
+}
+
 /* Selection color */
 ::selection {
   background: color-mix(in srgb, var(--accent) 25%, transparent);

--- a/src/components/contact-form.tsx
+++ b/src/components/contact-form.tsx
@@ -66,8 +66,8 @@ export const ContactForm = () => {
 
   if (state === "success") {
     return (
-      <div className="flex flex-col items-center gap-3 py-8 text-center">
-        <CheckCircle size={32} className="text-green-500" />
+      <div role="status" aria-live="polite" className="flex flex-col items-center gap-3 py-8 text-center">
+        <CheckCircle size={32} className="text-green-500" aria-hidden="true" />
         <p className="text-lg font-medium text-text-primary">{t("success")}</p>
         <p className="text-sm text-text-muted">{t("successSub")}</p>
         <button
@@ -103,11 +103,13 @@ export const ContactForm = () => {
           type="text"
           required
           autoComplete="name"
+          aria-describedby={fieldErrors.name ? "contact-name-error" : undefined}
+          aria-invalid={fieldErrors.name ? true : undefined}
           className={INPUT_CLASS}
           placeholder={t("namePlaceholder")}
         />
         {fieldErrors.name && (
-          <p className="mt-1 text-xs text-red-400">{fieldErrors.name}</p>
+          <p id="contact-name-error" role="alert" className="mt-1 text-xs text-red-400">{fieldErrors.name}</p>
         )}
       </div>
 
@@ -121,11 +123,13 @@ export const ContactForm = () => {
           type="email"
           required
           autoComplete="email"
+          aria-describedby={fieldErrors.email ? "contact-email-error" : undefined}
+          aria-invalid={fieldErrors.email ? true : undefined}
           className={INPUT_CLASS}
           placeholder={t("emailPlaceholder")}
         />
         {fieldErrors.email && (
-          <p className="mt-1 text-xs text-red-400">{fieldErrors.email}</p>
+          <p id="contact-email-error" role="alert" className="mt-1 text-xs text-red-400">{fieldErrors.email}</p>
         )}
       </div>
 
@@ -138,17 +142,19 @@ export const ContactForm = () => {
           name="message"
           required
           rows={4}
+          aria-describedby={fieldErrors.message ? "contact-message-error" : undefined}
+          aria-invalid={fieldErrors.message ? true : undefined}
           className={`${INPUT_CLASS} resize-none`}
           placeholder={t("messagePlaceholder")}
         />
         {fieldErrors.message && (
-          <p className="mt-1 text-xs text-red-400">{fieldErrors.message}</p>
+          <p id="contact-message-error" role="alert" className="mt-1 text-xs text-red-400">{fieldErrors.message}</p>
         )}
       </div>
 
       {state === "error" && (
-        <div className="flex items-center gap-2 rounded-lg border border-red-400/30 bg-red-400/10 px-4 py-3 text-sm text-red-400">
-          <AlertCircle size={16} />
+        <div role="alert" className="flex items-center gap-2 rounded-lg border border-red-400/30 bg-red-400/10 px-4 py-3 text-sm text-red-400">
+          <AlertCircle size={16} aria-hidden="true" />
           {error}
         </div>
       )}


### PR DESCRIPTION
## Что изменено

Аудит доступности WCAG 2.1 AA. Исправлены ключевые проблемы.

### Fixes
- **Global focus-visible ring** — `outline: 2px solid var(--accent)` для всех интерактивных элементов
- **aria-describedby** — форменные поля связаны с сообщениями об ошибках
- **aria-invalid** — поля с ошибками валидации помечены для screen readers
- **role='alert'** — ошибки форм анонсируются screen readers
- **role='status' + aria-live='polite'** — успешная отправка анонсируется
- **aria-hidden='true'** — декоративные иконки скрыты от screen readers

### Что уже было хорошо (не трогал)
- Skip-to-content link ✅
- aria-label на icon buttons ✅
- aria-expanded на мобильном меню ✅
- aria-current на nav links ✅
- Escape закрывает мобильное меню ✅
- min-h-[44px] touch targets ✅
- prefers-reduced-motion ✅
- HTML lang attribute ✅
- Form labels с htmlFor ✅

## Тип изменения
- [x] enhancement — улучшение

## Связанные Issues
Closes #132