### PR TITLE
seo: add BreadcrumbList JSON-LD to blog posts and case study pages

### DIFF
--- a/src/app/[locale]/blog/[slug]/page.tsx
+++ b/src/app/[locale]/blog/[slug]/page.tsx
@@ -6,6 +6,7 @@ import rehypePrettyCode from "rehype-pretty-code";
 import { getTranslations } from "next-intl/server";
 import { getPost, getSlugs } from "@/lib/blog";
 import { SITE_CONFIG } from "@/lib/site-config";
+import { buildBreadcrumbLd } from "@/lib/breadcrumb-ld";
 import { mdxComponents } from "@/components/mdx-components";
 import type { Metadata } from "next";
 
@@ -51,11 +52,20 @@ export default async function BlogPostPage({ params }: Props) {
     keywords: post.tags.join(", "),
   };
 
+  const breadcrumbLd = buildBreadcrumbLd([
+    { name: t("title"), path: "/blog" },
+    { name: post.title, path: `/blog/${slug}` },
+  ]);
+
   return (
     <>
       <script
         type="application/ld+json"
         dangerouslySetInnerHTML={{ __html: JSON.stringify(jsonLd) }}
+      />
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
       />
       <article className="mx-auto max-w-3xl px-6 py-32">
         <Link

--- a/src/app/[locale]/projects/[slug]/page.tsx
+++ b/src/app/[locale]/projects/[slug]/page.tsx
@@ -4,6 +4,7 @@ import { Link } from "@/i18n/routing";
 import { ArrowLeft, Clock, Zap, Target, Rocket } from "lucide-react";
 import { CASE_STUDIES, getCaseStudy } from "@/lib/case-studies";
 import { SITE_CONFIG } from "@/lib/site-config";
+import { buildBreadcrumbLd } from "@/lib/breadcrumb-ld";
 import type { Metadata } from "next";
 
 type Props = { params: Promise<{ locale: string; slug: string }> };
@@ -44,7 +45,17 @@ export default async function CaseStudyPage({ params }: Props) {
     { key: "result", icon: SECTION_ICONS.result, text: t(`${cs.slug}_result`) },
   ];
 
+  const breadcrumbLd = buildBreadcrumbLd([
+    { name: t("title"), path: "/#projects" },
+    { name: cs.title, path: `/projects/${cs.slug}` },
+  ]);
+
   return (
+    <>
+      <script
+        type="application/ld+json"
+        dangerouslySetInnerHTML={{ __html: JSON.stringify(breadcrumbLd) }}
+      />
     <div className="mx-auto max-w-3xl px-6 py-32">
       <Link
         href="/#projects"
@@ -141,5 +152,6 @@ export default async function CaseStudyPage({ params }: Props) {
         </div>
       </nav>
     </div>
+    </>
   );
 }

--- a/src/components/json-ld.tsx
+++ b/src/components/json-ld.tsx
@@ -10,9 +10,10 @@ const organizationSchema = {
   "@type": "Organization",
   name: SITE_CONFIG.name,
   url: BASE_URL,
-  logo: `${BASE_URL}/favicon.svg`,
+  logo: { "@type": "ImageObject", url: `${BASE_URL}/favicon.svg` },
   description: messages.meta.description,
   email: SITE_CONFIG.email,
+  foundingDate: String(SITE_CONFIG.established),
   sameAs: [SITE_CONFIG.github, SITE_CONFIG.telegram],
   knowsAbout: [...new Set(SERVICES.flatMap((s) => [...s.tags]))],
 };

--- a/src/lib/breadcrumb-ld.ts
+++ b/src/lib/breadcrumb-ld.ts
@@ -1,0 +1,24 @@
+import { SITE_CONFIG } from "@/lib/site-config";
+
+const BASE_URL = `https://${SITE_CONFIG.domain}`;
+
+interface BreadcrumbItem {
+  name: string;
+  path: string;
+}
+
+export function buildBreadcrumbLd(items: BreadcrumbItem[]) {
+  return {
+    "@context": "https://schema.org",
+    "@type": "BreadcrumbList",
+    itemListElement: [
+      { "@type": "ListItem", position: 1, name: SITE_CONFIG.name, item: BASE_URL },
+      ...items.map((item, i) => ({
+        "@type": "ListItem" as const,
+        position: i + 2,
+        name: item.name,
+        item: `${BASE_URL}${item.path}`,
+      })),
+    ],
+  };
+}


### PR DESCRIPTION
## Что изменено

BreadcrumbList structured data для внутренних страниц.

### Новое
- `src/lib/breadcrumb-ld.ts` — reusable helper `buildBreadcrumbLd()`
- Blog posts: Home → Blog → Post Title
- Case studies: Home → Projects → Project Title

### Уже было (не трогал)
- Organization schema (logo ImageObject, foundingDate, sameAs, knowsAbout) ✅
- WebSite schema ✅
- Service schemas (4 сервиса) ✅
- BlogPosting schema ✅

## Тип изменения
- [x] enhancement — улучшение

## Связанные Issues
Closes #134