### PR TITLE
infra: add /api/health endpoint + update Docker healthchecks

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -39,6 +39,6 @@ USER nextjs
 EXPOSE 3000
 
 HEALTHCHECK --interval=30s --timeout=5s --start-period=10s --retries=3 \
-  CMD node -e "fetch('http://localhost:3000/').then(r=>{process.exit(r.ok?0:1)}).catch(()=>process.exit(1))"
+  CMD node -e "fetch('http://localhost:3000/api/health').then(r=>{process.exit(r.ok?0:1)}).catch(()=>process.exit(1))"
 
 CMD ["node", "server.js"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -14,7 +14,7 @@ services:
     environment:
       - NODE_ENV=production
     healthcheck:
-      test: ["CMD", "node", "-e", "fetch('http://localhost:3000/').then(r=>{process.exit(r.ok?0:1)}).catch(()=>process.exit(1))"]
+      test: ["CMD", "node", "-e", "fetch('http://localhost:3000/api/health').then(r=>{process.exit(r.ok?0:1)}).catch(()=>process.exit(1))"]
       interval: 30s
       timeout: 5s
       start_period: 10s

--- a/src/app/api/health/route.ts
+++ b/src/app/api/health/route.ts
@@ -1,0 +1,31 @@
+import { NextResponse } from "next/server";
+
+const startedAt = Date.now();
+
+export async function GET() {
+  const uptimeMs = Date.now() - startedAt;
+  const uptimeSeconds = Math.floor(uptimeMs / 1000);
+
+  let version = "unknown";
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    const pkg = require("../../../../package.json") as { version: string };
+    version = pkg.version;
+  } catch {
+    // standalone build may not have package.json accessible
+  }
+
+  return NextResponse.json(
+    {
+      status: "ok",
+      version,
+      uptime: uptimeSeconds,
+      timestamp: new Date().toISOString(),
+      env: process.env.NODE_ENV ?? "unknown",
+    },
+    {
+      status: 200,
+      headers: { "Cache-Control": "no-store" },
+    },
+  );
+}


### PR DESCRIPTION
## Что изменено

Dedicated health endpoint + обновлённые Docker healthchecks.

### /api/health response
```json
{
  "status": "ok",
  "version": "0.9.0",
  "uptime": 3600,
  "timestamp": "2026-02-25T14:00:00.000Z",
  "env": "production"
}
```

### Изменения
- `src/app/api/health/route.ts` — GET endpoint, no-store cache
- `Dockerfile` — healthcheck → `/api/health`
- `docker-compose.yml` — healthcheck → `/api/health`

## Тип изменения
- [x] infra — CI/CD, деплой

## Связанные Issues
Closes #136