### PR TITLE
chore: v0.10.0 — Polish & Production Hardening milestone

### DIFF
--- a/.github/banner.svg
+++ b/.github/banner.svg
@@ -40,7 +40,7 @@
   <rect x="406" y="230" width="114" height="28" rx="14" fill="#111113" stroke="#27272a" stroke-width="1"/>
   <text x="418" y="249" font-family="monospace" font-size="11" fill="#a1a1aa">Framer Motion</text>
   <!-- version -->
-  <text x="60" y="295" font-family="monospace" font-size="11" letter-spacing="1.5" fill="#71717a">v0.9.0</text>
+  <text x="60" y="295" font-family="monospace" font-size="11" letter-spacing="1.5" fill="#71717a">v0.10.0</text>
   <!-- side decoration -->
   <line x1="840" y1="60" x2="840" y2="260" stroke="#27272a" stroke-width="1" stroke-dasharray="4 4"/>
   <text x="855" y="168" font-family="monospace" font-size="9" letter-spacing="3" fill="#3f3f46" transform="rotate(90, 855, 168)">essentialhustle.dev</text>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,28 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.10.0] - 2026-02-25
+
+### Added
+- **Health endpoint** — `GET /api/health` returning status, version, uptime, timestamp, env (#136)
+- **Automated deploy script** — `scripts/deploy.sh` with rsync sync, Docker rebuild, health check polling, and automatic rollback on failure (#135)
+- **BreadcrumbList JSON-LD** — structured data on blog posts and case study pages for SEO breadcrumb navigation (#134)
+- **Honeypot spam defense** — hidden field in contact form that silently drops bot submissions (#133)
+- **Global focus-visible ring** — keyboard accessibility with `outline: 2px solid accent` on all interactive elements (#132)
+- **README SVG conversion** — fully SVG-based README matching Sortina client pattern, zero raw markdown (#143)
+
+### Changed
+- **Caching headers** — `immutable` for hashed `_next/static`, `must-revalidate` for HTML, `stale-while-revalidate` for assets (#131)
+- **Docker healthcheck** — now uses `/api/health` endpoint instead of root page
+
+### Fixed
+- **Form accessibility** — `aria-describedby` linking inputs to error messages, `aria-invalid` on invalid fields, `role="alert"` on errors, `role="status"` on success (#132)
+- **Case study descriptions** — corrected all 4 project descriptions to match real codebases; MUX renamed from "Video Multiplexor" to "CRSF Relay" (#142)
+
+### Security
+- **Contact form honeypot** — bots that auto-fill hidden `website` field get silently accepted without processing (#133)
+- **Rate limiting** already existed (60s sliding window, IP-based) — now documented and honeypot added as secondary defense
+
 ## [0.9.0] - 2026-02-25
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "essential-hustle",
-  "version": "0.9.0",
+  "version": "0.10.0",
   "private": true,
   "scripts": {
     "dev": "next dev",


### PR DESCRIPTION
## Что изменено
Version bump v0.10.0 + CHANGELOG + banner sync.

## Milestone v0.10.0 — все issues закрыты
- #80 i18n middleware deprecated — already resolved (proxy.ts)
- #131 Caching headers — PR #148
- #132 Accessibility audit — PR #146
- #133 Rate limiting + honeypot — PR #145
- #134 JSON-LD BreadcrumbList — PR #147
- #135 Automated deploy script — PR #149
- #136 Health endpoint — PR #150
- #142 Case study descriptions fix
- #143 README SVG conversion — PR #144

## Тип изменения
- [x] chore — служебное